### PR TITLE
custom containers.yaml file test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,18 @@
 									</systemPropertyVariables>
 								</configuration>
 							</execution>
+                            <execution>
+                                <id>wf-custom</id>
+                                <goals><goal>test</goal></goals>
+                                <configuration>
+                                    <skip>false</skip>
+                                    <test>SimpleDeploymentTestCase</test>
+                                    <systemPropertyVariables>
+                                        <arq.container.chameleon.configuration.chameleonTarget>wildfly-custom:9.0.0.CR1:managed</arq.container.chameleon.configuration.chameleonTarget>
+                                        <arq.container.chameleon.configuration.chameleonContainerConfigurationFile>/containers.yaml</arq.container.chameleon.configuration.chameleonContainerConfigurationFile>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
 							<execution>
 								<id>gf4</id>
 								<goals><goal>test</goal></goals>

--- a/src/test/resources/containers.yaml
+++ b/src/test/resources/containers.yaml
@@ -1,0 +1,180 @@
+- name: JBoss EAP
+  versionExpression: 6.0.*
+  adapters:
+    - type: remote
+      gav: org.jboss.as:jboss-as-arquillian-container-remote:7.1.2.Final
+      adapterClass: org.jboss.as.arquillian.container.remote.RemoteDeployableContainer
+    - type: managed
+      gav: org.jboss.as:jboss-as-arquillian-container-managed:7.1.2.Final
+      adapterClass: org.jboss.as.arquillian.container.managed.ManagedDeployableContainer
+      configuration: &EAP_CONFIG
+        jbossHome: ${dist}
+    - type: embedded
+      gav: org.jboss.as:jboss-as-arquillian-container-embedded:7.1.2.Final
+      adapterClass: org.jboss.as.arquillian.container.embedded.EmbeddedDeployableContainer
+      configuration: *EAP_CONFIG
+  dist: &EAP_DIST
+    gav: org.jboss.as:jboss-as-dist:zip:${version}
+  exclude: &EAP_EXCLUDE
+    - org.jboss.arquillian.test:*
+    - org.jboss.arquillian.testenricher:*
+    - org.jboss.arquillian.container:*
+    - org.jboss.arquillian.core:*
+    - org.jboss.arquillian.config:*
+    - org.jboss.arquillian.protocol:*
+    - org.jboss.shrinkwrap.api:*
+    - org.jboss.shrinkwrap:*
+    - org.jboss.shrinkwrap.descriptors:*
+    - org.jboss.shrinkwrap.resolver:*
+    - "*:wildfly-arquillian-testenricher-msc"
+    - "*:wildfly-arquillian-protocol-jmx"
+    - "*:jboss-as-arquillian-testenricher-msc"
+    - "*:jboss-as-arquillian-protocol-jmx"
+- name: JBoss EAP
+  versionExpression: 6.*
+  adapters:
+    - type: remote
+      gav: org.jboss.as:jboss-as-arquillian-container-remote:7.1.3.Final
+      adapterClass: org.jboss.as.arquillian.container.remote.RemoteDeployableContainer
+    - type: managed
+      gav: org.jboss.as:jboss-as-arquillian-container-managed:7.1.3.Final
+      adapterClass: org.jboss.as.arquillian.container.managed.ManagedDeployableContainer
+      configuration: *EAP_CONFIG
+    - type: embedded
+      gav: org.jboss.as:jboss-as-arquillian-container-embedded:7.1.3.Final
+      adapterClass: org.jboss.as.arquillian.container.embedded.EmbeddedDeployableContainer
+      configuration: *EAP_CONFIG
+  dist: *EAP_DIST
+  exclude: *EAP_EXCLUDE
+- name: JBoss AS
+  versionExpression: 7.*
+  adapters:
+    - type: remote
+      gav: org.jboss.as:jboss-as-arquillian-container-remote:${version}
+      adapterClass: org.jboss.as.arquillian.container.remote.RemoteDeployableContainer
+    - type: managed
+      gav: org.jboss.as:jboss-as-arquillian-container-managed:${version}
+      adapterClass: org.jboss.as.arquillian.container.managed.ManagedDeployableContainer
+      configuration: &AS_CONFIG
+        jbossHome: ${dist}
+    - type: embedded
+      gav: org.jboss.as:jboss-as-arquillian-container-embedded:${version}
+      adapterClass: org.jboss.as.arquillian.container.embedded.EmbeddedDeployableContainer
+      configuration: *AS_CONFIG
+  dist: &AS_DIST
+    gav: org.jboss.as:jboss-as-dist:zip:${version}
+  exclude: &AS_EXCLUDE
+    - org.jboss.arquillian.test:*
+    - org.jboss.arquillian.testenricher:*
+    - org.jboss.arquillian.container:*
+    - org.jboss.arquillian.core:*
+    - org.jboss.arquillian.config:*
+    - org.jboss.arquillian.protocol:*
+    - org.jboss.shrinkwrap.api:*
+    - org.jboss.shrinkwrap:*
+    - org.jboss.shrinkwrap.descriptors:*
+    - org.jboss.shrinkwrap.resolver:*
+    - "*:wildfly-arquillian-testenricher-msc"
+    - "*:wildfly-arquillian-protocol-jmx"
+    - "*:jboss-as-arquillian-testenricher-msc"
+    - "*:jboss-as-arquillian-protocol-jmx"
+- name: WildFly
+  versionExpression: 8.*
+  adapters:
+    - type: remote
+      gav: org.wildfly:wildfly-arquillian-container-remote:${version}
+      adapterClass: org.jboss.as.arquillian.container.remote.RemoteDeployableContainer
+    - type: managed
+      gav: org.wildfly:wildfly-arquillian-container-managed:${version}
+      adapterClass: org.jboss.as.arquillian.container.managed.ManagedDeployableContainer
+      configuration: &WF_CONFIG
+        jbossHome: ${dist}
+    - type: embedded
+      gav: org.wildfly:wildfly-arquillian-container-embedded:${version}
+      adapterClass: org.jboss.as.arquillian.container.embedded.EmbeddedDeployableContainer
+      configuration: *WF_CONFIG
+  dist: &WF_DIST
+    gav: org.wildfly:wildfly-dist:zip:${version}
+  exclude: &WF_EXCLUDE
+    - org.jboss.arquillian.test:*
+    - org.jboss.arquillian.testenricher:*
+    - org.jboss.arquillian.container:*
+    - org.jboss.arquillian.core:*
+    - org.jboss.arquillian.config:*
+    - org.jboss.arquillian.protocol:*
+    - org.jboss.shrinkwrap.api:*
+    - org.jboss.shrinkwrap:*
+    - org.jboss.shrinkwrap.descriptors:*
+    - org.jboss.shrinkwrap.resolver:*
+    - "*:wildfly-arquillian-testenricher-msc"
+    - "*:wildfly-arquillian-protocol-jmx"
+    - "*:jboss-as-arquillian-testenricher-msc"
+    - "*:jboss-as-arquillian-protocol-jmx"
+- name: WildFly
+  versionExpression: 9.*
+  adapters:
+    - type: remote
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-remote:1.0.0.Alpha5
+      adapterClass: org.jboss.as.arquillian.container.remote.RemoteDeployableContainer
+    - type: managed
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-managed:1.0.0.Alpha5
+      adapterClass: org.jboss.as.arquillian.container.managed.ManagedDeployableContainer
+      configuration: *WF_CONFIG
+    - type: embedded
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-embedded:1.0.0.Alpha5
+      adapterClass: org.jboss.as.arquillian.container.embedded.EmbeddedDeployableContainer
+      configuration: *WF_CONFIG
+  dist: *WF_DIST
+  exclude: *WF_EXCLUDE
+
+- name: wildFly-custom
+  versionExpression: 9.*
+  adapters:
+    - type: remote
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-remote:1.0.0.Alpha5
+      adapterClass: org.jboss.as.arquillian.container.remote.RemoteDeployableContainer
+    - type: managed
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-managed:1.0.0.Alpha5
+      adapterClass: org.jboss.as.arquillian.container.managed.ManagedDeployableContainer
+      configuration: *WF_CONFIG
+    - type: embedded
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-embedded:1.0.0.Alpha5
+      adapterClass: org.jboss.as.arquillian.container.embedded.EmbeddedDeployableContainer
+      configuration: *WF_CONFIG
+  dist: *WF_DIST
+  exclude: *WF_EXCLUDE
+
+
+- name: GlassFish
+  versionExpression: 3.*
+  adapters:
+    - &GF_REMOTE
+      type: remote
+      gav: org.jboss.arquillian.container:arquillian-glassfish-remote-3.1:1.0.0.CR4
+      adapterClass: org.jboss.arquillian.container.glassfish.remote_3_1.GlassFishRestDeployableContainer
+    - &GF_MANAGED
+      type: managed
+      gav: org.jboss.arquillian.container:arquillian-glassfish-managed-3.1:1.0.0.CR4
+      adapterClass: org.jboss.arquillian.container.glassfish.managed_3_1.GlassFishManagedDeployableContainer
+      configuration:
+        glassFishHome: ${dist}
+    - type: embedded
+      gav: org.jboss.arquillian.container:arquillian-glassfish-embedded-3.1:1.0.0.CR4
+      adapterClass: org.jboss.arquillian.container.glassfish.embedded_3_1.GlassFishContainer
+      requireDist: false
+      dependencies:
+        - org.glassfish.extras:glassfish-embedded-all:${version}
+  dist: &GF_DIST
+    gav: org.glassfish.main.distributions:glassfish:zip:${version}
+- name: GlassFish
+  versionExpression: 4.*
+  adapters:
+    - *GF_REMOTE
+    - *GF_MANAGED
+    - type: embedded
+      gav: org.jboss.arquillian.container:arquillian-glassfish-embedded-3.1:1.0.0.CR4
+      adapterClass: org.jboss.arquillian.container.glassfish.embedded_3_1.GlassFishContainer
+      requireDist: false
+      dependencies:
+        - org.glassfish.main.extras:glassfish-embedded-all:${version}
+  dist: *GF_DIST


### PR DESCRIPTION
this PR adds a test for simulating issue #16.

The test is passing because the '/' is prefixing containers.yaml in chameleonContainerConfigurationFile systemPropertyVariable