### PR TITLE
Added hability to override gav

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -97,6 +97,30 @@ Define the container configuration file to use. Defaults to the containers.yaml 
 
 Define where Chameleon should store the resolver cache files. By default it will use 'chameleonDistributionDownloadFolder'/cache.
 
+==== chameleonGav
+
+Define adapter maven coordinates. By using this property you can use a container adapter with a different distribution:
+
+[source, xml]
+----
+<container qualifier="chameleon" default="true">
+    <configuration>
+        <property name="chameleonTarget">wildfly:8.0.0.Final:managed</property>
+        <property name="chameleonGav">org.wildfly:wildfly-dist:zip:8.2.0.Final</property>
+    </configuration>
+</container>
+---- 
+
+With the above configuration chameleon will use wildfly adapter 8.0.0 on top wildfly 8.2.0 distribution. 
+
+IMPORTANT: Make sure adapter is compatible with the provided distribution.
+
+The main use case for 'chameleonGav' is when user customizes a container distribution (e.g by adding custom modules or libraries) and provide it as a maven artifact to use as arquillian custom container.
+
+
+
+
+
 == Development
 
 If you want to add your own container configurations or contribute to the ones shipped as default with Chameleon you can

--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,18 @@
 									</systemPropertyVariables>
 								</configuration>
 							</execution>
+						  	<execution>
+								<id>wf82-gav-81</id>
+								<goals><goal>test</goal></goals>
+								<configuration>
+								    <skip>false</skip>
+								    <test>SimpleDeploymentTestCase</test>
+									<systemPropertyVariables>
+										<arq.container.chameleon.configuration.chameleonTarget>wildfly:8.2.0.Final:managed</arq.container.chameleon.configuration.chameleonTarget>
+										<arq.container.chameleon.configuration.chameleonGav>org.wildfly:wildfly-dist:zip:8.1.0.Final</arq.container.chameleon.configuration.chameleonGav>
+									</systemPropertyVariables>
+								</configuration>
+							</execution> 
 							<execution>
 								<id>wf81</id>
 								<goals><goal>test</goal></goals>

--- a/src/main/java/org/arquillian/container/chameleon/ChameleonConfiguration.java
+++ b/src/main/java/org/arquillian/container/chameleon/ChameleonConfiguration.java
@@ -7,6 +7,7 @@ import java.nio.file.Paths;
 
 import org.arquillian.container.chameleon.spi.model.Container;
 import org.arquillian.container.chameleon.spi.model.ContainerAdapter;
+import org.arquillian.container.chameleon.spi.model.Dist;
 import org.arquillian.container.chameleon.spi.model.Target;
 import org.jboss.arquillian.container.spi.ConfigurationException;
 import org.jboss.arquillian.container.spi.client.container.ContainerConfiguration;
@@ -23,6 +24,7 @@ public class ChameleonConfiguration implements ContainerConfiguration {
     private String chameleonContainerConfigurationFile = null;
     private String chameleonDistributionDownloadFolder  = null;
     private String chameleonResolveCacheFolder  = null;
+    private String chameleonGav = null;
 
     @Override
     public void validate() throws ConfigurationException {
@@ -50,6 +52,15 @@ public class ChameleonConfiguration implements ContainerConfiguration {
 
     public void setChameleonTarget(String target) {
         this.chameleonTarget = target;
+    }
+    
+
+    public String getChameleonGav() {
+        return chameleonGav;
+    }
+
+    public void setChameleonGav(String chameleonGav) {
+        this.chameleonGav = chameleonGav;
     }
 
     public String getChameleonContainerConfigurationFile() {
@@ -101,6 +112,9 @@ public class ChameleonConfiguration implements ContainerConfiguration {
         for (Container container : containers) {
             ContainerAdapter adapter = container.matches(target);
             if (adapter != null) {
+                if(chameleonGav != null && !"".equals(chameleonGav)){
+                    adapter.setDistribution(new Dist().ofGav(chameleonGav));
+                }
                 return adapter;
             }
         }

--- a/src/main/java/org/arquillian/container/chameleon/spi/model/Container.java
+++ b/src/main/java/org/arquillian/container/chameleon/spi/model/Container.java
@@ -39,4 +39,6 @@ public class Container {
         }
         return null;
     }
+    
+    
 }

--- a/src/main/java/org/arquillian/container/chameleon/spi/model/ContainerAdapter.java
+++ b/src/main/java/org/arquillian/container/chameleon/spi/model/ContainerAdapter.java
@@ -46,6 +46,10 @@ public class ContainerAdapter {
     public String distribution() {
         return resolve(dist.gav());
     }
+    
+    public void setDistribution(Dist dist) {
+        this.dist = dist;
+    }
 
     public String[] excludes() {
         return resolve(gavExcludeExpression);

--- a/src/main/java/org/arquillian/container/chameleon/spi/model/Dist.java
+++ b/src/main/java/org/arquillian/container/chameleon/spi/model/Dist.java
@@ -7,4 +7,9 @@ public class Dist {
     public String gav() {
         return gav;
     }
+    
+    public Dist ofGav(String gav) {
+         this.gav = gav;
+         return this;
+    }
 }

--- a/src/test/java/org/arquillian/container/chameleon/ManualUpdateContainerPropertiesTestCase.java
+++ b/src/test/java/org/arquillian/container/chameleon/ManualUpdateContainerPropertiesTestCase.java
@@ -12,13 +12,13 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-@RunWith(Arquillian.class)
+//@RunWith(Arquillian.class)
 public class ManualUpdateContainerPropertiesTestCase {
 
     @ArquillianResource
     private ContainerController cc;
 
-    @Test
+    //@Test
     public void shouldBeAbleToStartTargetContainerWithNewArguments() throws Exception {
         // Update configuration from arquillian.xml to bind to a new port
         cc.start("manual",

--- a/src/test/java/org/arquillian/container/chameleon/ManualUpdateContainerPropertiesTestCase.java
+++ b/src/test/java/org/arquillian/container/chameleon/ManualUpdateContainerPropertiesTestCase.java
@@ -12,13 +12,13 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-//@RunWith(Arquillian.class)
+@RunWith(Arquillian.class)
 public class ManualUpdateContainerPropertiesTestCase {
 
     @ArquillianResource
     private ContainerController cc;
 
-    //@Test
+    @Test
     public void shouldBeAbleToStartTargetContainerWithNewArguments() throws Exception {
         // Update configuration from arquillian.xml to bind to a new port
         cc.start("manual",


### PR DESCRIPTION
Hi @aslakknutsen,

I added a way to override chameleon gav by:

1. adding **chameleonGav** property; 
2. after adaper is resolved I just change its distribution to the provided gav.

Do you think its sufficient for #41? 

I've tested here at the company with our custom distribution and it works great, here is our arquillian.xml:

```
 <property name="chameleonGav">com.procergs:jboss-eap-dist:zip:6.4.Final</property>
 <property name="chameleonTarget">jboss eap:6.4.Final:${arquillian.container}</property>
```

no need for custom containers.yaml.

WDYT?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arquillian/arquillian-container-chameleon/42)
<!-- Reviewable:end -->
