### PR TITLE
Support Domain mode of WildFly and EAP servers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,7 @@
             <configuration>
               <excludes>
                 <exclude>**/*Manual*</exclude>
+                <exclude>**/*Domain*</exclude>
               </excludes>
             </configuration>
           </execution>
@@ -330,6 +331,20 @@
                   <test>SimpleDeploymentTestCase</test>
                   <systemPropertyVariables>
                     <arq.container.chameleon.configuration.chameleonTarget>payara:4.1.1.162:managed
+                    </arq.container.chameleon.configuration.chameleonTarget>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+              <execution>
+                <id>wf10-domain</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <skip>false</skip>
+                  <test>DomainDeploymentTestCase</test>
+                  <systemPropertyVariables>
+                    <arq.container.chameleon.configuration.chameleonTarget>wildfly domain:10.0.0.Final:managed
                     </arq.container.chameleon.configuration.chameleonTarget>
                   </systemPropertyVariables>
                 </configuration>

--- a/src/main/resources/chameleon/default/containers.yaml
+++ b/src/main/resources/chameleon/default/containers.yaml
@@ -2,17 +2,41 @@
   versionExpression: 7.*
   adapters:
     - type: remote
-      gav: org.wildfly.arquillian:wildfly-arquillian-container-remote:1.1.0.Alpha1
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-remote:2.0.0.Final
       adapterClass: org.jboss.as.arquillian.container.remote.RemoteDeployableContainer
     - type: managed
-      gav: org.wildfly.arquillian:wildfly-arquillian-container-managed:1.1.0.Alpha1
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-managed:2.0.0.Final
       adapterClass: org.jboss.as.arquillian.container.managed.ManagedDeployableContainer
       configuration: &EAP7_CONFIG
         jbossHome: ${dist}
     - type: embedded
-      gav: org.wildfly.arquillian:wildfly-arquillian-container-embedded:1.1.0.Alpha1
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-embedded:2.0.0.Final
       adapterClass: org.jboss.as.arquillian.container.embedded.EmbeddedDeployableContainer
       configuration: *EAP7_CONFIG
+  defaultType: managed
+  dist: &EAP7_DIST
+    gav: org.jboss.as:jboss-as-dist:zip:${version}
+  exclude: &EAP7_EXCLUDE
+    - org.jboss.arquillian.test:*
+    - org.jboss.arquillian.testenricher:*
+    - org.jboss.arquillian.container:*
+    - org.jboss.arquillian.core:*
+    - org.jboss.arquillian.config:*
+    - org.jboss.arquillian.protocol:*
+    - org.jboss.shrinkwrap.api:*
+    - org.jboss.shrinkwrap:*
+    - org.jboss.shrinkwrap.descriptors:*
+    - org.jboss.shrinkwrap.resolver:*
+- name: JBoss EAP Domain
+  versionExpression: 7.*
+  adapters:
+    - type: managed
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-domain-managed:2.0.0.Final
+      adapterClass: org.jboss.as.arquillian.container.domain.managed.ManagedDomainDeployableContainer
+      configuration: *EAP7_CONFIG
+    - type: remote
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-domain-remote:2.0.0.Final
+      adapterClass: org.jboss.as.arquillian.container.domain.remote.RemoteDomainDeployableContainer
   defaultType: managed
   dist: &EAP7_DIST
     gav: org.jboss.as:jboss-as-dist:zip:${version}
@@ -61,6 +85,35 @@
     - "*:wildfly-arquillian-protocol-jmx"
     - "*:jboss-as-arquillian-testenricher-msc"
     - "*:jboss-as-arquillian-protocol-jmx"
+- name: JBoss EAP Domain
+  versionExpression: 6.0.*
+  adapters:
+    - type: managed
+      gav: org.jboss.as:jboss-as-arquillian-container-domain-managed:7.1.2.Final
+      adapterClass: org.jboss.as.arquillian.container.domain.managed.ManagedDomainDeployableContainer
+      configuration: *EAP_CONFIG
+    - type: remote
+      gav: org.jboss.as:jboss-as-arquillian-container-domain-remote:7.1.2.Final
+      adapterClass: org.jboss.as.arquillian.container.domain.remote.RemoteDomainDeployableContainer
+  defaultType: managed
+  dist: &EAP_DIST
+    gav: org.jboss.as:jboss-as-dist:zip:${version}
+  defaultProtocol: Servlet 3.0
+  exclude: &EAP_EXCLUDE
+    - org.jboss.arquillian.test:*
+    - org.jboss.arquillian.testenricher:*
+    - org.jboss.arquillian.container:*
+    - org.jboss.arquillian.core:*
+    - org.jboss.arquillian.config:*
+    - org.jboss.arquillian.protocol:*
+    - org.jboss.shrinkwrap.api:*
+    - org.jboss.shrinkwrap:*
+    - org.jboss.shrinkwrap.descriptors:*
+    - org.jboss.shrinkwrap.resolver:*
+    - "*:wildfly-arquillian-testenricher-msc"
+    - "*:wildfly-arquillian-protocol-jmx"
+    - "*:jboss-as-arquillian-testenricher-msc"
+    - "*:jboss-as-arquillian-protocol-jmx"
 - name: JBoss EAP
   versionExpression: 6.*
   adapters:
@@ -75,6 +128,20 @@
       gav: org.jboss.as:jboss-as-arquillian-container-embedded:7.1.3.Final
       adapterClass: org.jboss.as.arquillian.container.embedded.EmbeddedDeployableContainer
       configuration: *EAP_CONFIG
+  defaultType: managed
+  dist: *EAP_DIST
+  defaultProtocol: Servlet 3.0
+  exclude: *EAP_EXCLUDE
+- name: JBoss EAP Domain
+  versionExpression: 6.*
+  adapters:
+    - type: managed
+      gav: org.jboss.as:jboss-as-arquillian-container-domain-managed:7.1.3.Final
+      adapterClass: org.jboss.as.arquillian.container.domain.managed.ManagedDomainDeployableContainer
+      configuration: *EAP_CONFIG
+    - type: remote
+      gav: org.jboss.as:jboss-as-arquillian-container-domain-remote:7.1.3.Final
+      adapterClass: org.jboss.as.arquillian.container.domain.remote.RemoteDomainDeployableContainer
   defaultType: managed
   dist: *EAP_DIST
   defaultProtocol: Servlet 3.0
@@ -94,6 +161,35 @@
       gav: org.jboss.as:jboss-as-arquillian-container-embedded:${version}
       adapterClass: org.jboss.as.arquillian.container.embedded.EmbeddedDeployableContainer
       configuration: *AS_CONFIG
+  defaultType: managed
+  dist: &AS_DIST
+    gav: org.jboss.as:jboss-as-dist:zip:${version}
+  defaultProtocol: Servlet 3.0
+  exclude: &AS_EXCLUDE
+    - org.jboss.arquillian.test:*
+    - org.jboss.arquillian.testenricher:*
+    - org.jboss.arquillian.container:*
+    - org.jboss.arquillian.core:*
+    - org.jboss.arquillian.config:*
+    - org.jboss.arquillian.protocol:*
+    - org.jboss.shrinkwrap.api:*
+    - org.jboss.shrinkwrap:*
+    - org.jboss.shrinkwrap.descriptors:*
+    - org.jboss.shrinkwrap.resolver:*
+    - "*:wildfly-arquillian-testenricher-msc"
+    - "*:wildfly-arquillian-protocol-jmx"
+    - "*:jboss-as-arquillian-testenricher-msc"
+    - "*:jboss-as-arquillian-protocol-jmx"
+- name: JBoss AS Domain
+  versionExpression: 7.*
+  adapters:
+    - type: managed
+      gav: org.jboss.as:jboss-as-arquillian-container-domain-managed:${version}
+      adapterClass: org.jboss.as.arquillian.container.domain.managed.ManagedDomainDeployableContainer
+      configuration: *AS_CONFIG
+    - type: remote
+      gav: org.jboss.as:jboss-as-arquillian-container-domain-remote:${version}
+      adapterClass: org.jboss.as.arquillian.container.domain.remote.RemoteDomainDeployableContainer
   defaultType: managed
   dist: &AS_DIST
     gav: org.jboss.as:jboss-as-dist:zip:${version}
@@ -149,6 +245,35 @@
     - "*:wildfly-arquillian-protocol-jmx"
     - "*:jboss-as-arquillian-testenricher-msc"
     - "*:jboss-as-arquillian-protocol-jmx"
+- name: WildFly Domain
+  versionExpression: 8.*
+  adapters:
+    - type: managed
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-domain-managed:${version}
+      adapterClass: org.jboss.as.arquillian.container.domain.managed.ManagedDomainDeployableContainer
+      configuration: *WF_CONFIG
+    - type: remote
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-domain-remote:${version}
+      adapterClass: org.jboss.as.arquillian.container.domain.remote.RemoteDomainDeployableContainer
+  defaultType: managed
+  dist: &WF_DIST
+    gav: org.wildfly:wildfly-dist:zip:${version}
+  defaultProtocol: Servlet 3.0
+  exclude: &WF_EXCLUDE
+    - org.jboss.arquillian.test:*
+    - org.jboss.arquillian.testenricher:*
+    - org.jboss.arquillian.container:*
+    - org.jboss.arquillian.core:*
+    - org.jboss.arquillian.config:*
+    - org.jboss.arquillian.protocol:*
+    - org.jboss.shrinkwrap.api:*
+    - org.jboss.shrinkwrap:*
+    - org.jboss.shrinkwrap.descriptors:*
+    - org.jboss.shrinkwrap.resolver:*
+    - "*:wildfly-arquillian-testenricher-msc"
+    - "*:wildfly-arquillian-protocol-jmx"
+    - "*:jboss-as-arquillian-testenricher-msc"
+    - "*:jboss-as-arquillian-protocol-jmx"
 - name: WildFly
   versionExpression: 9.*
   adapters:
@@ -177,18 +302,42 @@
     - org.jboss.shrinkwrap.descriptors:*
     - org.jboss.shrinkwrap.resolver:*
     - "*:wildfly-arquillian-testenricher-msc"
+- name: WildFly Domain
+  versionExpression: 9.*
+  adapters:
+    - type: managed
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-domain-managed:1.0.0.Final
+      adapterClass: org.jboss.as.arquillian.container.domain.managed.ManagedDomainDeployableContainer
+      configuration: *WF_CONFIG
+    - type: remote
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-domain-remote:1.0.0.Final
+      adapterClass: org.jboss.as.arquillian.container.domain.remote.RemoteDomainDeployableContainer
+  defaultType: managed
+  dist: *WF_DIST
+  exclude: &WF9_EXCLUDE
+    - org.jboss.arquillian.test:*
+    - org.jboss.arquillian.testenricher:*
+    - org.jboss.arquillian.container:*
+    - org.jboss.arquillian.core:*
+    - org.jboss.arquillian.config:*
+    - org.jboss.arquillian.protocol:*
+    - org.jboss.shrinkwrap.api:*
+    - org.jboss.shrinkwrap:*
+    - org.jboss.shrinkwrap.descriptors:*
+    - org.jboss.shrinkwrap.resolver:*
+    - "*:wildfly-arquillian-testenricher-msc"
 - name: WildFly
   versionExpression: 10.*
   adapters:
     - type: remote
-      gav: org.wildfly.arquillian:wildfly-arquillian-container-remote:1.0.0.Final
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-remote:2.0.0.Final
       adapterClass: org.jboss.as.arquillian.container.remote.RemoteDeployableContainer
     - type: managed
-      gav: org.wildfly.arquillian:wildfly-arquillian-container-managed:1.0.0.Final
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-managed:2.0.0.Final
       adapterClass: org.jboss.as.arquillian.container.managed.ManagedDeployableContainer
       configuration: *WF_CONFIG
     - type: embedded
-      gav: org.wildfly.arquillian:wildfly-arquillian-container-embedded:1.0.0.Final
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-embedded:2.0.0.Final
       adapterClass: org.jboss.as.arquillian.container.embedded.EmbeddedDeployableContainer
       configuration: *WF_CONFIG
   defaultType: managed
@@ -205,7 +354,30 @@
     - org.jboss.shrinkwrap.descriptors:*
     - org.jboss.shrinkwrap.resolver:*
     - "*:wildfly-arquillian-testenricher-msc"
-
+- name: WildFly Domain
+  versionExpression: 10.*
+  adapters:
+    - type: managed
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-domain-managed:2.0.0.Final
+      adapterClass: org.jboss.as.arquillian.container.domain.managed.ManagedDomainDeployableContainer
+      configuration: *WF_CONFIG
+    - type: remote
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-domain-remote:2.0.0.Final
+      adapterClass: org.jboss.as.arquillian.container.domain.remote.RemoteDomainDeployableContainer
+  defaultType: managed
+  dist: *WF_DIST
+  exclude: &WF10_EXCLUDE
+    - org.jboss.arquillian.test:*
+    - org.jboss.arquillian.testenricher:*
+    - org.jboss.arquillian.container:*
+    - org.jboss.arquillian.core:*
+    - org.jboss.arquillian.config:*
+    - org.jboss.arquillian.protocol:*
+    - org.jboss.shrinkwrap.api:*
+    - org.jboss.shrinkwrap:*
+    - org.jboss.shrinkwrap.descriptors:*
+    - org.jboss.shrinkwrap.resolver:*
+    - "*:wildfly-arquillian-testenricher-msc"
 # Older versions of Glassfish (before 3.1.2) are no longer supported
 - name: GlassFish
   versionExpression: ^3\.1\.[2-9]{1}(\.[0-9])*$

--- a/src/test/java/org/arquillian/container/chameleon/ContainerTestCase.java
+++ b/src/test/java/org/arquillian/container/chameleon/ContainerTestCase.java
@@ -37,6 +37,22 @@ public class ContainerTestCase {
     }
 
     @Test
+    public void resolveJBossAS7DomainManaged() throws Exception {
+        ContainerAdapter adapter = load("jboss as domain:7.1.1.Final:managed");
+        Assert.assertEquals(
+                "org.jboss.as:jboss-as-arquillian-container-domain-managed:7.1.1.Final",
+                adapter.dependencies()[0]);
+    }
+
+    @Test
+    public void resolveJBossAS7DomainRemote() throws Exception {
+        ContainerAdapter adapter = load("jboss as domain:7.1.1.Final:remote");
+        Assert.assertEquals(
+                "org.jboss.as:jboss-as-arquillian-container-domain-remote:7.1.1.Final",
+                adapter.dependencies()[0]);
+    }
+
+    @Test
     public void overrideDefaultProtocolJBossAs7() throws Exception {
         ContainerAdapter adapter = load("jboss as:7.1.1.Final:managed");
         Assert.assertTrue(
@@ -104,7 +120,7 @@ public class ContainerTestCase {
     public void resolveJBossEAP7() throws Exception {
         ContainerAdapter adapter = load("jboss eap:7.0.0.GA:managed");
         Assert.assertEquals(
-                "org.wildfly.arquillian:wildfly-arquillian-container-managed:1.1.0.Alpha1",
+                "org.wildfly.arquillian:wildfly-arquillian-container-managed:2.0.0.Final",
                 adapter.dependencies()[0]);
     }
 
@@ -179,7 +195,23 @@ public class ContainerTestCase {
     public void resolveWildFly10() throws Exception {
         ContainerAdapter adapter = load("wildfly:10.0.0.Beta2:managed");
         Assert.assertEquals(
-                "org.wildfly.arquillian:wildfly-arquillian-container-managed:1.0.0.Final",
+                "org.wildfly.arquillian:wildfly-arquillian-container-managed:2.0.0.Final",
+                adapter.dependencies()[0]);
+    }
+
+    @Test
+    public void resolveWildFly10DomainManaged() throws Exception {
+        ContainerAdapter adapter = load("wildfly domain:10.0.0.Final:managed");
+        Assert.assertEquals(
+                "org.wildfly.arquillian:wildfly-arquillian-container-domain-managed:2.0.0.Final",
+                adapter.dependencies()[0]);
+    }
+
+    @Test
+    public void resolveWildFly10DomainRemote() throws Exception {
+        ContainerAdapter adapter = load("wildfly domain:10.0.0.Final:remote");
+        Assert.assertEquals(
+                "org.wildfly.arquillian:wildfly-arquillian-container-domain-remote:2.0.0.Final",
                 adapter.dependencies()[0]);
     }
 

--- a/src/test/java/org/arquillian/container/chameleon/DomainDeploymentTestCase.java
+++ b/src/test/java/org/arquillian/container/chameleon/DomainDeploymentTestCase.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.arquillian.container.chameleon;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+@RunWith(Arquillian.class)
+public class DomainDeploymentTestCase {
+
+    @Deployment
+    @TargetsContainer("main-server-group")
+    public static WebArchive deploy() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClass(SimpleBean.class);
+    }
+
+    @Inject
+    private SimpleBean bean;
+
+    @Test
+    public void shouldNotBeNull() {
+        Assert.assertNotNull(bean);
+    }
+
+    @Test
+    public void shouldReturnName() {
+        Assert.assertEquals("Proxy", bean.getName());
+    }
+}


### PR DESCRIPTION
The version for WildFly 10 is 1.1.0.Beta1 on purpose. There was a problem with starting the server with version 1.0.0 and it was fixed in 1.1.0.Beta1.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arquillian/arquillian-container-chameleon/44)

<!-- Reviewable:end -->
