### PR TITLE
Adds Payara 4.1.x configuration

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -73,6 +73,8 @@ Example chameleonTarget values:
 * GlassFish
 ** 3.x
 ** 4.x
+* Payara
+** 4.1.x
 
 [NOTE]
 Chameleon will download and extract the target container if no distribution home is configured and target type is either embedded or managed.

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
             </configuration>
 
             <executions>
-              <execution>
+            <execution>
                 <id>wf10</id>
                 <goals>
                   <goal>test</goal>
@@ -308,7 +308,7 @@
                 </configuration>
               </execution>
               <execution>
-                <id>gf41</id>
+                <id>gf41-managed</id>
                 <goals>
                   <goal>test</goal>
                 </goals>
@@ -317,6 +317,20 @@
                   <test>SimpleDeploymentTestCase</test>
                   <systemPropertyVariables>
                     <arq.container.chameleon.configuration.chameleonTarget>glassfish:4.1:managed
+                    </arq.container.chameleon.configuration.chameleonTarget>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+              <execution>
+                <id>payara41-managed</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <skip>false</skip>
+                  <test>SimpleDeploymentTestCase</test>
+                  <systemPropertyVariables>
+                    <arq.container.chameleon.configuration.chameleonTarget>payara:4.1.1.162:managed
                     </arq.container.chameleon.configuration.chameleonTarget>
                   </systemPropertyVariables>
                 </configuration>

--- a/src/main/resources/chameleon/default/containers.yaml
+++ b/src/main/resources/chameleon/default/containers.yaml
@@ -263,6 +263,3 @@
   defaultType: managed
   dist:
     gav: fish.payara.distributions:payara:zip:${version}
-  exclude:
-      - org.apache.xalan:*
-      - org.apache.xerces:*

--- a/src/main/resources/chameleon/default/containers.yaml
+++ b/src/main/resources/chameleon/default/containers.yaml
@@ -241,3 +241,28 @@
         - org.glassfish.main.extras:glassfish-embedded-all:${version}
   defaultType: managed
   dist: *GF_DIST
+
+- name: Payara
+  versionExpression: 4.*
+  adapters:
+    - type: remote
+      gav: org.jboss.arquillian.container:arquillian-glassfish-remote-3.1:1.0.0.CR4
+      adapterClass: org.jboss.arquillian.container.glassfish.remote_3_1.GlassFishRestDeployableContainer
+    - type: managed
+      gav: org.jboss.arquillian.container:arquillian-glassfish-managed-3.1:1.0.0.CR4
+      adapterClass: org.jboss.arquillian.container.glassfish.managed_3_1.GlassFishManagedDeployableContainer
+      configuration:
+        glassFishHome: ${dist}
+        debug: true
+    - type: embedded
+      gav: org.jboss.arquillian.container:arquillian-glassfish-embedded-3.1:1.0.0.CR4
+      adapterClass: org.jboss.arquillian.container.glassfish.embedded_3_1.GlassFishContainer
+      requireDist: false
+      dependencies:
+        - fish.payara.extras:payara-embedded-all:${version}
+  defaultType: managed
+  dist:
+    gav: fish.payara.distributions:payara:zip:${version}
+  exclude:
+      - org.apache.xalan:*
+      - org.apache.xerces:*


### PR DESCRIPTION
There are two problems with the current setup

1. Our tests are failing for `embedded` gf an payara
2. `all` profile should probably be split between Java EE 6 and EE 7 containers. At least for `embedded` ones it makes a difference.

I will work on (1) soon in the separated PR. Wanted to create this one to have a reference for other issues regarding container support so new contributors can have some hints how to do that.