### PR TITLE
Drops support for GlassFish versions older than 3.1.2 by restricting version pattern

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -71,13 +71,16 @@ Example chameleonTarget values:
 * JBoss AS
 ** 7.x
 * GlassFish
-** 3.x
+** 3.1.2.*
 ** 4.x
 * Payara
-** 4.1.x
+** 4.x
 
 [NOTE]
 Chameleon will download and extract the target container if no distribution home is configured and target type is either embedded or managed.
+
+[IMPORTANT]
+Glassfish versions prior to 3.1.2 are no longer supported due to issues with dependencies of the distribution
 
 === Configuration options
 

--- a/src/main/resources/chameleon/default/containers.yaml
+++ b/src/main/resources/chameleon/default/containers.yaml
@@ -206,54 +206,46 @@
     - org.jboss.shrinkwrap.resolver:*
     - "*:wildfly-arquillian-testenricher-msc"
 
+# Older versions of Glassfish (before 3.1.2) are no longer supported
 - name: GlassFish
-  versionExpression: 3.*
+  versionExpression: ^3\.1\.[2-9]{1}(\.[0-9])*$
   adapters:
     - &GF_REMOTE
-      type: remote
-      gav: org.jboss.arquillian.container:arquillian-glassfish-remote-3.1:1.0.0.CR4
-      adapterClass: org.jboss.arquillian.container.glassfish.remote_3_1.GlassFishRestDeployableContainer
+          type: remote
+          gav: org.jboss.arquillian.container:arquillian-glassfish-remote-3.1:1.0.0.CR4
+          adapterClass: org.jboss.arquillian.container.glassfish.remote_3_1.GlassFishRestDeployableContainer
     - &GF_MANAGED
       type: managed
       gav: org.jboss.arquillian.container:arquillian-glassfish-managed-3.1:1.0.0.CR4
       adapterClass: org.jboss.arquillian.container.glassfish.managed_3_1.GlassFishManagedDeployableContainer
       configuration:
         glassFishHome: ${dist}
-    - type: embedded
-      gav: org.jboss.arquillian.container:arquillian-glassfish-embedded-3.1:1.0.0.CR4
-      adapterClass: org.jboss.arquillian.container.glassfish.embedded_3_1.GlassFishContainer
-      requireDist: false
-      dependencies:
-        - org.glassfish.extras:glassfish-embedded-all:${version}
-  defaultType: managed
-  dist: &GF_DIST
-    gav: org.glassfish.main.distributions:glassfish:zip:${version}
-- name: GlassFish
-  versionExpression: 4.*
-  adapters:
-    - *GF_REMOTE
-    - *GF_MANAGED
-    - type: embedded
+        outputToConsole: true
+    - &GF_EMBEDDED
+      type: embedded
       gav: org.jboss.arquillian.container:arquillian-glassfish-embedded-3.1:1.0.0.CR4
       adapterClass: org.jboss.arquillian.container.glassfish.embedded_3_1.GlassFishContainer
       requireDist: false
       dependencies:
         - org.glassfish.main.extras:glassfish-embedded-all:${version}
   defaultType: managed
+  dist: &GF_DIST
+    gav: org.glassfish.main.distributions:glassfish:zip:${version}
+
+- name: GlassFish
+  versionExpression: 4.*
+  adapters:
+    - *GF_REMOTE
+    - *GF_MANAGED
+    - *GF_EMBEDDED
+  defaultType: managed
   dist: *GF_DIST
 
 - name: Payara
   versionExpression: 4.*
   adapters:
-    - type: remote
-      gav: org.jboss.arquillian.container:arquillian-glassfish-remote-3.1:1.0.0.CR4
-      adapterClass: org.jboss.arquillian.container.glassfish.remote_3_1.GlassFishRestDeployableContainer
-    - type: managed
-      gav: org.jboss.arquillian.container:arquillian-glassfish-managed-3.1:1.0.0.CR4
-      adapterClass: org.jboss.arquillian.container.glassfish.managed_3_1.GlassFishManagedDeployableContainer
-      configuration:
-        glassFishHome: ${dist}
-        debug: true
+    - *GF_REMOTE
+    - *GF_MANAGED
     - type: embedded
       gav: org.jboss.arquillian.container:arquillian-glassfish-embedded-3.1:1.0.0.CR4
       adapterClass: org.jboss.arquillian.container.glassfish.embedded_3_1.GlassFishContainer


### PR DESCRIPTION
First of all dependencies for GF prior to 3.1.2 are different than what we have defined. Thus it's not working at all.

Trying to make it work however brings several issues:

* Dependencies somehow required by `zip` distributions are either not reachable (DNS fails for `glassfish.org` repo... surprise surprise)
  * Solution for it is to provide an ability to define additional repos for given container which will be added to `MavenResolver` (maybe new feature before we release?)
* Even when I provided additional repos and artifact could have been resolved it was complaining about missing OSGi bundled for managed GlassFish - is it worth an effort to bring support for such old containers then?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arquillian/arquillian-container-chameleon/48)
<!-- Reviewable:end -->
