### PR TITLE
Added missing dependencies to WF embedded configurations; added test

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -160,6 +160,31 @@ use the following format to describe them:
 NOTE: If you want to help improve the configurations, you can find issues related to this configuration labeled as https://github.com/arquillian/arquillian-container-chameleon/labels/container[container]
 in the https://github.com/arquillian/arquillian-container-chameleon/issues[issue tracker].
 
+==== WildFly Embedded
+If you want to run any of the versions of WildFly embedded, you need to add an additional dependency to your pom.xml file:
+[source,xml]
+----
+<dependency>
+    <groupId>org.jboss.logmanager</groupId>
+    <artifactId>jboss-logmanager</artifactId>
+    <version>${jboss.logmanager.version}</version>
+</dependency>
+----
+and set `java.util.logging.manager` variable to `org.jboss.logmanager.LogManager` using `maven-surefire-plugin`:
+[source,xml]
+----
+<plugin>
+    <artifactId>maven-surefire-plugin</artifactId>
+    <configuration>
+        <systemPropertyVariables>
+            <java.util.logging.manager>
+                org.jboss.logmanager.LogManager
+            </java.util.logging.manager>
+        </systemPropertyVariables>
+    </configuration>
+</plugin>
+----
+
 == Test
 
 To run the whole test suite with the correct configuration use profile `all`:

--- a/pom.xml
+++ b/pom.xml
@@ -99,11 +99,6 @@
       <type>pom</type>
     </dependency>
     <dependency>
-      <groupId>org.jboss.logmanager</groupId>
-      <artifactId>jboss-logmanager</artifactId>
-      <version>${version.jboss.logmanager}</version>
-    </dependency>
-    <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
       <artifactId>arquillian-junit-container</artifactId>
       <scope>test</scope>
@@ -420,6 +415,14 @@
           </plugin>
         </plugins>
       </build>
+      <dependencies>
+        <dependency>
+          <groupId>org.jboss.logmanager</groupId>
+          <artifactId>jboss-logmanager</artifactId>
+          <version>${version.jboss.logmanager}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
     </profile>
     <profile>
       <id>tck</id>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <version.arquillian_core>1.1.11.Final</version.arquillian_core>
     <version.arquillian_tck>1.0.0.Alpha1</version.arquillian_tck>
     <version.jboss.javaee-6_api>1.0.0.Final</version.jboss.javaee-6_api>
+    <version.jboss.logmanager>2.0.4.Final</version.jboss.logmanager>
 
     <!-- override from parent -->
     <maven.compiler.target>1.5</maven.compiler.target>
@@ -96,6 +97,11 @@
       <groupId>org.jboss.shrinkwrap.resolver</groupId>
       <artifactId>shrinkwrap-resolver-depchain</artifactId>
       <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logmanager</groupId>
+      <artifactId>jboss-logmanager</artifactId>
+      <version>${version.jboss.logmanager}</version>
     </dependency>
     <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
@@ -347,6 +353,67 @@
                     <arq.container.chameleon.configuration.chameleonTarget>wildfly domain:10.0.0.Final:managed
                     </arq.container.chameleon.configuration.chameleonTarget>
                   </systemPropertyVariables>
+                </configuration>
+              </execution>
+              <!-- WF embedded -->
+              <execution>
+                <id>wf8-embedded</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <skip>false</skip>
+                  <test>SimpleDeploymentTestCase</test>
+                  <systemPropertyVariables>
+                    <arq.container.chameleon.configuration.chameleonTarget>wildfly:8.0.0.Final:embedded
+                    </arq.container.chameleon.configuration.chameleonTarget>
+                  </systemPropertyVariables>
+                  <systemProperties>
+                    <property>
+                      <name>java.util.logging.manager</name>
+                      <value>org.jboss.logmanager.LogManager</value>
+                    </property>
+                  </systemProperties>
+                </configuration>
+              </execution>
+              <execution>
+                <id>wf9-embedded</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <skip>false</skip>
+                  <test>SimpleDeploymentTestCase</test>
+                  <systemPropertyVariables>
+                    <arq.container.chameleon.configuration.chameleonTarget>wildfly:9.0.0.Final:embedded
+                    </arq.container.chameleon.configuration.chameleonTarget>
+                  </systemPropertyVariables>
+                  <systemProperties>
+                    <property>
+                      <name>java.util.logging.manager</name>
+                      <value>org.jboss.logmanager.LogManager</value>
+                    </property>
+                  </systemProperties>
+                </configuration>
+              </execution>
+              <execution>
+                <id>wf10-embedded</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <skip>false</skip>
+                  <test>SimpleDeploymentTestCase</test>
+                  <systemPropertyVariables>
+                    <arq.container.chameleon.configuration.chameleonTarget>wildfly:10.0.0.Final:embedded
+                    </arq.container.chameleon.configuration.chameleonTarget>
+                  </systemPropertyVariables>
+                  <systemProperties>
+                    <property>
+                      <name>java.util.logging.manager</name>
+                      <value>org.jboss.logmanager.LogManager</value>
+                    </property>
+                  </systemProperties>
                 </configuration>
               </execution>
             </executions>

--- a/src/main/resources/chameleon/default/containers.yaml
+++ b/src/main/resources/chameleon/default/containers.yaml
@@ -226,6 +226,9 @@
       configuration: &WF_EMBEDD_CONFIG
         jbossHome: ${dist}
         modulePath: ${dist}/modules
+      dependencies:
+        - org.jboss.remotingjmx:remoting-jmx:2.0.1.Final
+        - org.jboss.logging:jboss-logging:3.2.1.Final
   defaultType: managed
   dist: &WF_DIST
     gav: org.wildfly:wildfly-dist:zip:${version}
@@ -288,6 +291,8 @@
       gav: org.wildfly.arquillian:wildfly-arquillian-container-embedded:1.0.0.Final
       adapterClass: org.jboss.as.arquillian.container.embedded.EmbeddedDeployableContainer
       configuration: *WF_EMBEDD_CONFIG
+      dependencies:
+        - org.jboss.remotingjmx:remoting-jmx:2.0.1.Final
   defaultType: managed
   dist: *WF_DIST
   exclude: &WF9_EXCLUDE


### PR DESCRIPTION
Added missing dependencies into WF embedded configurations:
WF8 
`org.jboss.remotingjmx:remoting-jmx:2.0.1.Final`
`org.jboss.logging:jboss-logging:3.2.1.Final`
WF9
`org.jboss.remotingjmx:remoting-jmx:2.0.1.Final`
into the containers.yaml file. Without these dependencies the containers failed.

All of the WF embedded containers requires a dependency `org.jboss.logmanager:jboss-logmanager`  and the property `java.util.logging.manager` has to be set to `org.jboss.logmanager.LogManager`. I added the dependency to the list of dependencies to be transitively fetched into a developer's project (not sure if it is correct approach or not). The only thing that developer has to do to make the container running is to set the property.

Added also test execution configurations into the `all` profile