### PR TITLE
Updated all WF adapters of 2.x.y stream to 2.0.1.Final

### DIFF
--- a/src/main/resources/chameleon/default/containers.yaml
+++ b/src/main/resources/chameleon/default/containers.yaml
@@ -2,15 +2,15 @@
   versionExpression: 7.*
   adapters:
     - type: remote
-      gav: org.wildfly.arquillian:wildfly-arquillian-container-remote:2.0.0.Final
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-remote:2.0.1.Final
       adapterClass: org.jboss.as.arquillian.container.remote.RemoteDeployableContainer
     - type: managed
-      gav: org.wildfly.arquillian:wildfly-arquillian-container-managed:2.0.0.Final
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-managed:2.0.1.Final
       adapterClass: org.jboss.as.arquillian.container.managed.ManagedDeployableContainer
       configuration: &EAP7_CONFIG
         jbossHome: ${dist}
     - type: embedded
-      gav: org.wildfly.arquillian:wildfly-arquillian-container-embedded:2.0.0.Final
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-embedded:2.0.1.Final
       adapterClass: org.jboss.as.arquillian.container.embedded.EmbeddedDeployableContainer
       configuration: *EAP7_CONFIG
   defaultType: managed
@@ -31,11 +31,11 @@
   versionExpression: 7.*
   adapters:
     - type: managed
-      gav: org.wildfly.arquillian:wildfly-arquillian-container-domain-managed:2.0.0.Final
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-domain-managed:2.0.1.Final
       adapterClass: org.jboss.as.arquillian.container.domain.managed.ManagedDomainDeployableContainer
       configuration: *EAP7_CONFIG
     - type: remote
-      gav: org.wildfly.arquillian:wildfly-arquillian-container-domain-remote:2.0.0.Final
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-domain-remote:2.0.1.Final
       adapterClass: org.jboss.as.arquillian.container.domain.remote.RemoteDomainDeployableContainer
   defaultType: managed
   dist: &EAP7_DIST
@@ -335,14 +335,14 @@
   versionExpression: 10.*
   adapters:
     - type: remote
-      gav: org.wildfly.arquillian:wildfly-arquillian-container-remote:2.0.0.Final
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-remote:2.0.1.Final
       adapterClass: org.jboss.as.arquillian.container.remote.RemoteDeployableContainer
     - type: managed
-      gav: org.wildfly.arquillian:wildfly-arquillian-container-managed:2.0.0.Final
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-managed:2.0.1.Final
       adapterClass: org.jboss.as.arquillian.container.managed.ManagedDeployableContainer
       configuration: *WF_CONFIG
     - type: embedded
-      gav: org.wildfly.arquillian:wildfly-arquillian-container-embedded:2.0.0.Final
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-embedded:2.0.1.Final
       adapterClass: org.jboss.as.arquillian.container.embedded.EmbeddedDeployableContainer
       configuration: *WF_EMBEDD_CONFIG
   defaultType: managed
@@ -363,11 +363,11 @@
   versionExpression: 10.*
   adapters:
     - type: managed
-      gav: org.wildfly.arquillian:wildfly-arquillian-container-domain-managed:2.0.0.Final
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-domain-managed:2.0.1.Final
       adapterClass: org.jboss.as.arquillian.container.domain.managed.ManagedDomainDeployableContainer
       configuration: *WF_CONFIG
     - type: remote
-      gav: org.wildfly.arquillian:wildfly-arquillian-container-domain-remote:2.0.0.Final
+      gav: org.wildfly.arquillian:wildfly-arquillian-container-domain-remote:2.0.1.Final
       adapterClass: org.jboss.as.arquillian.container.domain.remote.RemoteDomainDeployableContainer
   defaultType: managed
   dist: *WF_DIST

--- a/src/test/java/org/arquillian/container/chameleon/ContainerTestCase.java
+++ b/src/test/java/org/arquillian/container/chameleon/ContainerTestCase.java
@@ -120,7 +120,7 @@ public class ContainerTestCase {
     public void resolveJBossEAP7() throws Exception {
         ContainerAdapter adapter = load("jboss eap:7.0.0.GA:managed");
         Assert.assertEquals(
-                "org.wildfly.arquillian:wildfly-arquillian-container-managed:2.0.0.Final",
+                "org.wildfly.arquillian:wildfly-arquillian-container-managed:2.0.1.Final",
                 adapter.dependencies()[0]);
     }
 
@@ -173,7 +173,7 @@ public class ContainerTestCase {
     public void resolveWildFly9() throws Exception {
         ContainerAdapter adapter = load("wildfly:9.0.0.CR1:managed");
         Assert.assertEquals(
-                "org.wildfly.arquillian:wildfly-arquillian-container-managed:1.0.0.Final",
+                "org.wildfly.arquillian:wildfly-arquillian-container-managed:1.1.0.Final",
                 adapter.dependencies()[0]);
     }
 
@@ -195,7 +195,7 @@ public class ContainerTestCase {
     public void resolveWildFly10() throws Exception {
         ContainerAdapter adapter = load("wildfly:10.0.0.Beta2:managed");
         Assert.assertEquals(
-                "org.wildfly.arquillian:wildfly-arquillian-container-managed:2.0.0.Final",
+                "org.wildfly.arquillian:wildfly-arquillian-container-managed:2.0.1.Final",
                 adapter.dependencies()[0]);
     }
 
@@ -203,7 +203,7 @@ public class ContainerTestCase {
     public void resolveWildFly10DomainManaged() throws Exception {
         ContainerAdapter adapter = load("wildfly domain:10.0.0.Final:managed");
         Assert.assertEquals(
-                "org.wildfly.arquillian:wildfly-arquillian-container-domain-managed:2.0.0.Final",
+                "org.wildfly.arquillian:wildfly-arquillian-container-domain-managed:2.0.1.Final",
                 adapter.dependencies()[0]);
     }
 
@@ -211,7 +211,7 @@ public class ContainerTestCase {
     public void resolveWildFly10DomainRemote() throws Exception {
         ContainerAdapter adapter = load("wildfly domain:10.0.0.Final:remote");
         Assert.assertEquals(
-                "org.wildfly.arquillian:wildfly-arquillian-container-domain-remote:2.0.0.Final",
+                "org.wildfly.arquillian:wildfly-arquillian-container-domain-remote:2.0.1.Final",
                 adapter.dependencies()[0]);
     }
 


### PR DESCRIPTION
On 15-Dec-2016, there has been released a new release of `2.0.x` WF adapter versions. 
in the testcase, there wasn't changed a version of: `org.wildfly.arquillian:wildfly-arquillian-container-managed` to `1.1.0.Final` when the update to the newer version was performed: https://github.com/arquillian/arquillian-container-chameleon/commit/d0e6bbbef238d3b531b51aa6b4b225700b095fd8