### PR TITLE
Now using correct version expression for JBoss AS 7.

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -69,7 +69,8 @@ Example chameleonTarget values:
 ** 9.x
 ** 8.x
 * JBoss AS
-** 7.x
+** 7.0.*
+** 7.1.0.* to 7.1.1.* (version > 7.1.1.* are not supported.)
 * GlassFish
 ** 3.1.2.*
 ** 4.x

--- a/arquillian-chameleon-container-model/src/main/resources/chameleon/default/containers.yaml
+++ b/arquillian-chameleon-container-model/src/main/resources/chameleon/default/containers.yaml
@@ -147,7 +147,7 @@
   defaultProtocol: Servlet 3.0
   exclude: *EAP_EXCLUDE
 - name: JBoss AS
-  versionExpression: 7.*
+  versionExpression: 7\.0\.[0-2]\.(.*)$|7\.1\.[0-1]\.(.*)$
   adapters:
     - type: remote
       coordinates: org.jboss.as:jboss-as-arquillian-container-remote:${version}
@@ -181,7 +181,7 @@
     - "*:jboss-as-arquillian-testenricher-msc"
     - "*:jboss-as-arquillian-protocol-jmx"
 - name: JBoss AS Domain
-  versionExpression: 7.*
+  versionExpression: 7\.0\.[0-2]\.(.*)$|7\.1\.[0-1]\.(.*)$
   adapters:
     - type: managed
       coordinates: org.jboss.as:jboss-as-arquillian-container-domain-managed:${version}

--- a/arquillian-chameleon-container-model/src/test/java/org/arquillian/container/chameleon/spi/model/TargetTest.java
+++ b/arquillian-chameleon-container-model/src/test/java/org/arquillian/container/chameleon/spi/model/TargetTest.java
@@ -7,26 +7,56 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TargetTest {
 
     @Test
-    public void shouldReturnFalseForMissingContainerName() throws Exception {
+    public void should_not_support_for_missing_container() throws Exception {
         Target target = Target.from("MISSING_TARGET:8.2.0.Final:managed");
         assertThat(target.isSupported()).isFalse();
     }
 
     @Test
-    public void shouldReturnTrueForGivenContainerName() throws Exception {
+    public void should_support_for_valid_wildfly_container() throws Exception {
         Target target = Target.from("wildfly:8.2.0.Final:managed");
         assertThat(target.isSupported()).isTrue();
     }
 
     @Test
-    public void shouldReturnTrueForTomcatContainer() throws Exception {
+    public void should_support_for_valid_tomcat_container() throws Exception {
         Target target = Target.from("Tomcat:7.0.47:Remote");
         assertThat(target.isSupported()).isTrue();
     }
 
     @Test
-    public void shouldReturnFalseForInvalidTomcatContainer() throws Exception {
+    public void should_not_support_for_invalid_tomcat_container() throws Exception {
         Target target = Target.from("Tomcat`:7.0.47:Remote");
+        assertThat(target.isSupported()).isFalse();
+    }
+
+    @Test
+    public void target_should_supported_for_jboss_as_7_0_1_Container() throws Exception {
+        final Target target = Target.from("JBoss AS:7.0.1.Final:managed");
+        assertThat(target.isSupported()).isTrue();
+    }
+
+    @Test
+    public void target_should_supported_for_jboss_as_7_0_2_Container() throws Exception {
+        final Target target = Target.from("JBoss AS:7.0.2.Final:remote");
+        assertThat(target.isSupported()).isTrue();
+    }
+
+    @Test
+    public void target_should_not_supported_for_jboss_as_7_1_3_container() throws Exception {
+        final Target target = Target.from("JBoss AS:7.1.3.Final:managed");
+        assertThat(target.isSupported()).isFalse();
+    }
+
+    @Test
+    public void target_should_supported_for_jboss_as_7_1_1_container() throws Exception {
+        final Target target = Target.from("JBoss AS:7.1.1.Final:embedded");
+        assertThat(target.isSupported()).isTrue();
+    }
+
+    @Test
+    public void target_should_not_supported_for_jboss_as_7_1_2_container() throws Exception {
+        final Target target = Target.from("JBoss AS:7.1.2.Final:managed");
         assertThat(target.isSupported()).isFalse();
     }
 }


### PR DESCRIPTION

#### Short description of what this resolves:
Changed version Expression of JBoss AS 7 to support only 7.[0-1].[0-2].*

#### Changes proposed in this pull request:

- Changed version expression of JBoss As 7


**Fixes**: #71 
