### PR TITLE
Correct the Gradle output directory

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -97,7 +97,7 @@ container configuration. Use no type if you just want 'something' up and running
 ==== chameleonDistributionDownloadFolder
 
 Override the default download folder for container distributions. Could be defined as `TMP` to create a custom folder under `java.io.tmpdir`, else
-it will be read as a directory. Defaults to detect current build system, either `target/` for Maven or `bin/` for Gradle.
+it will be read as a directory. Defaults to detect current build system, either `target/` for Maven or `build/` for Gradle.
 
 ==== chameleonContainerConfigurationFile
 

--- a/arquillian-chameleon-extension/src/main/java/org/arquillian/container/chameleon/ChameleonConfiguration.java
+++ b/arquillian-chameleon-extension/src/main/java/org/arquillian/container/chameleon/ChameleonConfiguration.java
@@ -31,7 +31,7 @@ import org.jboss.arquillian.container.spi.client.container.ContainerConfiguratio
 public class ChameleonConfiguration implements ContainerConfiguration {
 
     private static final String MAVEN_OUTPUT_DIRECTORY = "target";
-    private static final String GRADLE_OUTPUT_DIRECTORY = "bin";
+    private static final String GRADLE_OUTPUT_DIRECTORY = "build";
     private static final String TMP_FOLDER_EXPRESSION = "TMP";
 
     private static final String DEFAULT_CONTAINER_MAPPING = "chameleon/default/containers.yaml";


### PR DESCRIPTION
Chameleon doesn't correctly detect a Gradle build, it assumes Gradle output is written to the `bin` directory, this means downloaded artifacts are stored in `target/server` when they should be stored in `build/server`.

This patch corrects the Gradle output directory name.