### PR TITLE
Updated GlassFish adapters to 1.0.1

### DIFF
--- a/arquillian-chameleon-container-model/src/main/resources/chameleon/default/containers.yaml
+++ b/arquillian-chameleon-container-model/src/main/resources/chameleon/default/containers.yaml
@@ -389,18 +389,18 @@
   adapters:
     - &GF_REMOTE
           type: remote
-          coordinates: org.jboss.arquillian.container:arquillian-glassfish-remote-3.1:1.0.0.Final
+          coordinates: org.jboss.arquillian.container:arquillian-glassfish-remote-3.1:1.0.1
           adapterClass: org.jboss.arquillian.container.glassfish.remote_3_1.GlassFishRestDeployableContainer
     - &GF_MANAGED
       type: managed
-      coordinates: org.jboss.arquillian.container:arquillian-glassfish-managed-3.1:1.0.0.Final
+      coordinates: org.jboss.arquillian.container:arquillian-glassfish-managed-3.1:1.0.1
       adapterClass: org.jboss.arquillian.container.glassfish.managed_3_1.GlassFishManagedDeployableContainer
       configuration:
         glassFishHome: ${dist}
         outputToConsole: true
     - &GF_EMBEDDED
       type: embedded
-      coordinates: org.jboss.arquillian.container:arquillian-glassfish-embedded-3.1:1.0.0.Final
+      coordinates: org.jboss.arquillian.container:arquillian-glassfish-embedded-3.1:1.0.1
       adapterClass: org.jboss.arquillian.container.glassfish.embedded_3_1.GlassFishContainer
       requireDist: false
       dependencies:
@@ -424,7 +424,7 @@
     - *GF_REMOTE
     - *GF_MANAGED
     - type: embedded
-      coordinates: org.jboss.arquillian.container:arquillian-glassfish-embedded-3.1:1.0.0.Final
+      coordinates: org.jboss.arquillian.container:arquillian-glassfish-embedded-3.1:1.0.1
       adapterClass: org.jboss.arquillian.container.glassfish.embedded_3_1.GlassFishContainer
       requireDist: false
       dependencies:


### PR DESCRIPTION
Updates the GlassFish adapters to version 1.0.1, I've found these to be more reliable when running tests with GlassFish 4.1.2.