### PR TITLE
Add support for GlassFish 5.0

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -74,6 +74,7 @@ Example chameleonTarget values:
 * GlassFish
 ** 3.1.2.*
 ** 4.x
+** 5.x
 * Payara
 ** 4.x
 * Tomcat

--- a/arquillian-chameleon-container-model/src/main/resources/chameleon/default/containers.yaml
+++ b/arquillian-chameleon-container-model/src/main/resources/chameleon/default/containers.yaml
@@ -418,6 +418,15 @@
   defaultType: managed
   dist: *GF_DIST
 
+- name: GlassFish
+  versionExpression: 5.*
+  adapters:
+    - *GF_REMOTE
+    - *GF_MANAGED
+    - *GF_EMBEDDED
+  defaultType: managed
+  dist: *GF_DIST
+
 - name: Payara
   versionExpression: 4.*
   adapters:

--- a/arquillian-chameleon-extension/pom.xml
+++ b/arquillian-chameleon-extension/pom.xml
@@ -275,6 +275,20 @@
                   </systemPropertyVariables>
                 </configuration>
               </execution>
+              <execution>
+                <id>gf50-managed</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <skip>false</skip>
+                  <test>SimpleDeploymentTestCase</test>
+                  <systemPropertyVariables>
+                    <arq.container.chameleon.configuration.chameleonTarget>glassfish:5.0:managed
+                    </arq.container.chameleon.configuration.chameleonTarget>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
               <!-- Payara -->
               <execution>
                 <id>payara41-managed</id>


### PR DESCRIPTION
Adds support for GlassFish 5.0. Using the managed and remote adapters work but I've been unable to create a working test using the embedded adaptor, and trying the embedded adaptor with GlassFish 4.0 and 4.1 also fail for the same reason.