### PR TITLE
feat(#79): introduces starter artifacts to simplify container dependencies.

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -20,18 +20,25 @@ Chameleons are a tall, lizard-looking alien race that has (same as their earthli
 
 === Get Started
 
-Do whatever you http://arquillian.org/guides/getting_started/[would do normally] and add Chameleon Container instead of any application-server specific artifact:
+Do whatever you http://arquillian.org/guides/getting_started/[would do normally] and add Chameleon JUnit or TestNG Container starters instead of any application-server specific artifact:
 
 [source, xml]
+.arquillian-chameleon-junit-container-starter
 ----
 <dependency>
-    <groupId>org.jboss.arquillian.junit</groupId>
-    <artifactId>arquillian-junit-container</artifactId>
+    <groupId>org.arquillian.container</groupId>
+    <artifactId>arquillian-chameleon-junit-container-starter</artifactId>
+    <version>1.0.0.Final-SNAPSHOT</version>
     <scope>test</scope>
 </dependency>
+----
+
+[source, xml]
+.arquillian-chameleon-testng-container-starter
+----
 <dependency>
     <groupId>org.arquillian.container</groupId>
-    <artifactId>arquillian-container-chameleon</artifactId>
+    <artifactId>arquillian-chameleon-testng-container-starter</artifactId>
     <version>1.0.0.Final-SNAPSHOT</version>
     <scope>test</scope>
 </dependency>

--- a/arquillian-chameleon-container-model/pom.xml
+++ b/arquillian-chameleon-container-model/pom.xml
@@ -11,6 +11,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>arquillian-chameleon-container-model</artifactId>
+  <name>Arquillian Chameleon Container Model</name>
 
   <dependencies>
     <dependency>

--- a/arquillian-chameleon-junit-container-starter/pom.xml
+++ b/arquillian-chameleon-junit-container-starter/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>arquillian-container-chameleon-parent</artifactId>
+    <groupId>org.arquillian.container</groupId>
+    <version>1.0.0.Final-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <packaging>jar</packaging>
+
+  <artifactId>arquillian-chameleon-junit-container-starter</artifactId>
+  <name>Arquillian Chameleon JUnit Container Starter</name>
+  <description>Optimized dependencyManagement for the Arquillian Chameleon and JUnit Container Project</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-container</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.arquillian.container</groupId>
+      <artifactId>arquillian-container-chameleon</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/arquillian-chameleon-testng-container-starter/pom.xml
+++ b/arquillian-chameleon-testng-container-starter/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>arquillian-container-chameleon-parent</artifactId>
+    <groupId>org.arquillian.container</groupId>
+    <version>1.0.0.Final-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <packaging>jar</packaging>
+
+  <artifactId>arquillian-chameleon-testng-container-starter</artifactId>
+  <name>Arquillian Chameleon TestNG Container Starter</name>
+  <description>Optimized dependencyManagement for the Arquillian Chameleon and TestNG Container Project</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jboss.arquillian.testng</groupId>
+      <artifactId>arquillian-testng-container</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.arquillian.container</groupId>
+      <artifactId>arquillian-container-chameleon</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,8 @@
   <modules>
     <module>arquillian-chameleon-container-model</module>
     <module>arquillian-chameleon-extension</module>
+    <module>arquillian-chameleon-junit-container-starter</module>
+    <module>arquillian-chameleon-testng-container-starter</module>
   </modules>
 
   <name>Arquillian Container Chameleon Parent</name>


### PR DESCRIPTION
#### Short description of what this resolves:
Packages set of commonly used Chameleon and JUnit/TestNG container dependencies together in a jar module to be used as a single entity for improving user adoption.

#### Changes proposed in this pull request:

- Adds `chameleon starter` artifacts `arquillian-chameleon-junit-container-starter` and `arquillian-chameleon-testng-container-starter` for JUnit and TestNG respectively.
- Updates README accordingly.

**Fixes**: #79 
