### PR TITLE
feat(#88): Adds module attribute in MavenBuild

### DIFF
--- a/arquillian-chameleon-deployments/arquillian-chameleon-maven-build-deployment/src/main/java/org/arquillian/container/chameleon/deployment/maven/MavenBuild.java
+++ b/arquillian-chameleon-deployments/arquillian-chameleon-maven-build-deployment/src/main/java/org/arquillian/container/chameleon/deployment/maven/MavenBuild.java
@@ -13,6 +13,7 @@ public @interface MavenBuild {
     String version() default "3.5.0";
     String[] profiles() default {};
     String pom() default "pom.xml";
+    String module() default "";
     String localRepositoryDirectory() default "";
     boolean offline() default false;
     String mvnOpts() default "";

--- a/arquillian-chameleon-deployments/arquillian-chameleon-maven-build-deployment/src/main/java/org/arquillian/container/chameleon/deployment/maven/MavenBuildAutomaticDeployment.java
+++ b/arquillian-chameleon-deployments/arquillian-chameleon-maven-build-deployment/src/main/java/org/arquillian/container/chameleon/deployment/maven/MavenBuildAutomaticDeployment.java
@@ -1,12 +1,15 @@
 package org.arquillian.container.chameleon.deployment.maven;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Arrays;
 import org.arquillian.container.chameleon.deployment.api.AbstractAutomaticDeployment;
 import org.jboss.arquillian.test.spi.TestClass;
 import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.BuiltProject;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.EmbeddedMaven;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.pom.equipped.ConfigurationDistributionStage;
+import org.jboss.shrinkwrap.resolver.impl.maven.embedded.BuiltProjectImpl;
 
 public class MavenBuildAutomaticDeployment extends AbstractAutomaticDeployment {
 
@@ -49,9 +52,35 @@ public class MavenBuildAutomaticDeployment extends AbstractAutomaticDeployment {
             configurationDistributionStage.addProperty(properties[i], properties[i + 1]);
         }
 
-        return configurationDistributionStage
+        BuiltProject build = configurationDistributionStage
             .ignoreFailure()
-            .build().getDefaultBuiltArchive();
+            .build();
+
+        if (isModuleSet(conf)) {
+            final File projectDirectory = build.getModel().getProjectDirectory();
+            final Path normalize = projectDirectory.toPath().normalize();
+
+            final String relativeModuleDirectory = conf.module().replace('/', File.separatorChar);
+
+            build = getSubmodule(build,
+                normalize.toString() + File.separator + relativeModuleDirectory + File.separator + "pom.xml");
+        }
+
+        return build.getDefaultBuiltArchive();
+
+    }
+
+    private boolean isModuleSet(MavenBuild conf) {
+        return !"".equals(conf.module());
+    }
+
+    private BuiltProject getSubmodule(BuiltProject builtProject, String pomfile) {
+        BuiltProjectImpl submodule = new BuiltProjectImpl(
+            pomfile
+        );
+        submodule.setMavenBuildExitCode(builtProject.getMavenBuildExitCode());
+        submodule.setMavenLog(builtProject.getMavenLog());
+        return submodule;
     }
 
     private boolean isNotEmptyOrNull(String value) {

--- a/arquillian-chameleon-deployments/arquillian-chameleon-maven-build-deployment/src/test/java/org/arquillian/container/chameleon/deployment/maven/MavenBuildAutomaticDeploymentTest.java
+++ b/arquillian-chameleon-deployments/arquillian-chameleon-maven-build-deployment/src/test/java/org/arquillian/container/chameleon/deployment/maven/MavenBuildAutomaticDeploymentTest.java
@@ -1,0 +1,31 @@
+package org.arquillian.container.chameleon.deployment.maven;
+
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MavenBuildAutomaticDeploymentTest {
+
+    @Test
+    public void should_get_archive_from_module() {
+
+        // given
+        MavenBuildAutomaticDeployment mavenBuildAutomaticDeployment = new MavenBuildAutomaticDeployment();
+
+        // when
+        final Archive<?> archive = mavenBuildAutomaticDeployment.build(new TestClass(TestCaseClass.class));
+
+        // then
+        assertThat(archive.toString())
+            .startsWith("arquillian-chameleon-deployment-api");
+    }
+
+    @MavenBuild(pom = "../../pom.xml",
+        module = "arquillian-chameleon-deployments/arquillian-chameleon-deployment-api"
+    )
+    static class TestCaseClass {
+    }
+
+}


### PR DESCRIPTION
#### Short description of what this resolves:

Adds `module` attribute

#### Changes proposed in this pull request:

- Adds `module` attribute so user can set the archive to deploy.

**Fixes**: #88 
