### PR TITLE
Implement Gradle-equivalent to @MavenBuild: @GradleBuild

### DIFF
--- a/arquillian-chameleon-deployments/arquillian-chameleon-gradle-build-deployment/pom.xml
+++ b/arquillian-chameleon-deployments/arquillian-chameleon-gradle-build-deployment/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>arquillian-container-chameleon-parent</artifactId>
+    <groupId>org.arquillian.container</groupId>
+    <version>1.0.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>arquillian-chameleon-gradle-build-deployment</artifactId>
+
+  <name>Arquillian Chameleon Gradle Build Deployment</name>
+
+  <properties>
+  	<version.gradle-tooling-api>4.0.1</version.gradle-tooling-api>
+  </properties>
+
+  <repositories>
+  	<repository>
+  	  <id>gradle</id>
+  	  <name>gradle</name>
+  	  <url>http://repo.gradle.org/gradle/libs-releases-local</url>
+  	</repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-test-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.arquillian.container</groupId>
+      <artifactId>arquillian-chameleon-deployment-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+	    <groupId>org.gradle</groupId>
+	    <artifactId>gradle-tooling-api</artifactId>
+	    <version>${version.gradle-tooling-api}</version>
+    </dependency>
+    <dependency>
+    	<groupId>org.jboss.shrinkwrap</groupId>
+	    <artifactId>shrinkwrap-api</artifactId>
+	    <version>1.2.6</version>
+	</dependency>
+    <dependency>
+    	<groupId>org.jboss.shrinkwrap</groupId>
+	    <artifactId>shrinkwrap-impl-base</artifactId>
+	    <version>1.2.6</version>
+	</dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/arquillian-chameleon-deployments/arquillian-chameleon-gradle-build-deployment/src/main/java/org/arquillian/container/chameleon/deployment/gradle/GradleBuild.java
+++ b/arquillian-chameleon-deployments/arquillian-chameleon-gradle-build-deployment/src/main/java/org/arquillian/container/chameleon/deployment/gradle/GradleBuild.java
@@ -1,0 +1,30 @@
+package org.arquillian.container.chameleon.deployment.gradle;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface GradleBuild {
+
+    /**
+     * Gradle Project directory to run the build from
+     * @return radle Project directory relative to current module. By default current directory is used.
+     */
+    String path() default ".";
+    
+    /**
+     * Tasks to execute for building archive.
+     * @return List of goals
+     */
+    String[] tasks() default "build";
+
+    /**
+     * In case of disabling quiet mode, Gradle output is printed to console.
+     * The output is generated with "--info --stacktrace".
+     * @return 
+     */
+    boolean quiet() default true;
+}

--- a/arquillian-chameleon-deployments/arquillian-chameleon-gradle-build-deployment/src/main/java/org/arquillian/container/chameleon/deployment/gradle/GradleBuildAutomaticDeployment.java
+++ b/arquillian-chameleon-deployments/arquillian-chameleon-gradle-build-deployment/src/main/java/org/arquillian/container/chameleon/deployment/gradle/GradleBuildAutomaticDeployment.java
@@ -1,0 +1,75 @@
+package org.arquillian.container.chameleon.deployment.gradle;
+
+import java.io.File;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.arquillian.container.chameleon.deployment.api.AbstractAutomaticDeployment;
+import org.gradle.tooling.BuildLauncher;
+import org.gradle.tooling.GradleConnector;
+import org.gradle.tooling.ProjectConnection;
+import org.gradle.tooling.model.GradleProject;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.importer.ZipImporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+public class GradleBuildAutomaticDeployment extends AbstractAutomaticDeployment {
+
+    @Override
+    protected Archive<?> build(TestClass testClass) {
+        if (testClass.isAnnotationPresent(GradleBuild.class)) {
+            final GradleBuild gradleBuildDeployment = testClass.getAnnotation(GradleBuild.class);
+            return runBuild(gradleBuildDeployment);
+        }
+        return null;
+    }
+
+    private Archive<?> runBuild(GradleBuild conf) {
+    	
+    	ProjectConnection projectConnector = GradleConnector
+    		.newConnector()
+    		.forProjectDirectory(new File(conf.path()))
+    		.connect();
+    	
+    	BuildLauncher launcher = projectConnector
+    		.newBuild()
+    		.forTasks(conf.tasks())
+    		.withArguments("-x", "test");
+    	
+    	if (!conf.quiet()) {
+	    	launcher.withArguments("--info", "--stacktrace");
+	    	launcher.setStandardOutput(System.out);
+	        launcher.setStandardError(System.err);
+    	}
+    	launcher.run();
+    	
+    	GradleProject projectModel = projectConnector.getModel(GradleProject.class);
+		final Path artifactDir = projectModel.getBuildDirectory().toPath().resolve("libs");
+		
+		Path artifactPath = null;
+		try (DirectoryStream<Path> filesInArtifactDir = Files.newDirectoryStream(artifactDir)) {
+			for (Path file : filesInArtifactDir) {
+                if (file.toString().endsWith(".war")) {
+                	artifactPath = file;
+                	break;
+                }
+            }
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+			
+		if (artifactPath == null) {
+			throw new RuntimeException("No .war-file found in " + artifactDir.toString() + ".");
+		}
+		
+		return ShrinkWrap
+				  .create(ZipImporter.class, artifactPath.getFileName().toString())
+				  .importFrom(artifactPath.toFile())
+				  .as(WebArchive.class);
+
+    }
+
+}

--- a/arquillian-chameleon-deployments/arquillian-chameleon-gradle-build-deployment/src/main/java/org/arquillian/container/chameleon/deployment/gradle/GradleRunner.java
+++ b/arquillian-chameleon-deployments/arquillian-chameleon-gradle-build-deployment/src/main/java/org/arquillian/container/chameleon/deployment/gradle/GradleRunner.java
@@ -1,0 +1,7 @@
+package org.arquillian.container.chameleon.deployment.gradle;
+
+import org.jboss.shrinkwrap.api.Archive;
+
+public interface GradleRunner {
+    Archive<?> run(GradleBuild conf);
+}

--- a/arquillian-chameleon-deployments/arquillian-chameleon-gradle-build-deployment/src/main/resources/META-INF/services/org.jboss.arquillian.container.test.spi.client.deployment.AutomaticDeployment
+++ b/arquillian-chameleon-deployments/arquillian-chameleon-gradle-build-deployment/src/main/resources/META-INF/services/org.jboss.arquillian.container.test.spi.client.deployment.AutomaticDeployment
@@ -1,0 +1,1 @@
+org.arquillian.container.chameleon.deployment.gradle.GradleBuildAutomaticDeployment

--- a/arquillian-chameleon-deployments/arquillian-chameleon-gradle-build-deployment/src/test/java/org/arquillian/container/chameleon/deployment/gradle/GradleBuildAutomaticDeploymentTest.java
+++ b/arquillian-chameleon-deployments/arquillian-chameleon-gradle-build-deployment/src/test/java/org/arquillian/container/chameleon/deployment/gradle/GradleBuildAutomaticDeploymentTest.java
@@ -1,0 +1,25 @@
+package org.arquillian.container.chameleon.deployment.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+
+public class GradleBuildAutomaticDeploymentTest {
+
+    @Test
+    public void should_build_archive() {
+        GradleBuildAutomaticDeployment gradle = new GradleBuildAutomaticDeployment();
+        Archive<?> archive = gradle.build(new TestClass(TestCaseClass.class));
+
+        assertThat(archive.contains("/WEB-INF/classes/org/arquillian/example/helloworld/GreetingService.class"))
+        	.isTrue();
+    }
+    
+    @GradleBuild(path="../hello-world-example")
+    static class TestCaseClass {
+    	
+    }
+
+}

--- a/arquillian-chameleon-deployments/ftest-arquillian-chameleon-gradle-build-deployment/pom.xml
+++ b/arquillian-chameleon-deployments/ftest-arquillian-chameleon-gradle-build-deployment/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>arquillian-container-chameleon-parent</artifactId>
+    <groupId>org.arquillian.container</groupId>
+    <version>1.0.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>arquillian-chameleon-gradle-build-deployment-ftest</artifactId>
+
+  <name>Arquillian Chameleon Gradle Build Deployment Functional Test</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.arquillian.container</groupId>
+      <artifactId>arquillian-chameleon-gradle-build-deployment</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.arquillian.container</groupId>
+      <artifactId>arquillian-chameleon-junit-container-starter</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <version>3.0.7</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- This artifact shouldn't be deployed to maven repository -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>
+

--- a/arquillian-chameleon-deployments/ftest-arquillian-chameleon-gradle-build-deployment/src/test/java/org/arquillian/container/chameleon/deployment/GreetingServiceTest.java
+++ b/arquillian-chameleon-deployments/ftest-arquillian-chameleon-gradle-build-deployment/src/test/java/org/arquillian/container/chameleon/deployment/GreetingServiceTest.java
@@ -1,0 +1,36 @@
+package org.arquillian.container.chameleon.deployment;
+
+import static io.restassured.RestAssured.given;
+
+import java.net.URL;
+
+import org.arquillian.container.chameleon.api.ChameleonTarget;
+import org.arquillian.container.chameleon.deployment.api.DeploymentParameters;
+import org.arquillian.container.chameleon.deployment.gradle.GradleBuild;
+import org.arquillian.container.chameleon.runner.ArquillianChameleon;
+import org.hamcrest.CoreMatchers;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(ArquillianChameleon.class)
+@ChameleonTarget("wildfly:9.0.0.Final:managed")
+@GradleBuild(path = "../hello-world-example/")
+@DeploymentParameters(testable = false)
+public class GreetingServiceTest {
+
+    @ArquillianResource
+    private URL url;
+
+    @Test
+    public void should_get_greetings() {
+
+        given()
+            .get(url)
+            .then()
+            .assertThat()
+            .body(CoreMatchers.is("Hello World"));
+
+    }
+
+}

--- a/arquillian-chameleon-deployments/hello-world-example/build.gradle
+++ b/arquillian-chameleon-deployments/hello-world-example/build.gradle
@@ -1,0 +1,21 @@
+apply plugin: 'war'
+apply plugin: 'maven'
+
+group = 'org.arquillian.example'
+version = '1.0.0-SNAPSHOT'
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+    providedCompile 'javax:javaee-api:7.0'
+}
+
+test {
+    
+}
+
+war {
+  archiveName 'helloworld.war'
+}

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,8 @@
     <module>arquillian-chameleon-deployments/ftest-arquillian-chameleon-maven-build-deployment</module>
     <module>arquillian-chameleon-deployments/ftest-arquillian-chameleon-file-deployment</module>
     <module>arquillian-chameleon-deployments/arquillian-chameleon-file-deployment</module>
+    <module>arquillian-chameleon-deployments/arquillian-chameleon-gradle-build-deployment</module>
+    <module>arquillian-chameleon-deployments/ftest-arquillian-chameleon-gradle-build-deployment</module>
     <module>arquillian-chameleon-deployments/hello-world-example</module>
   </modules>
 


### PR DESCRIPTION
#### Short description of what this resolves:

Minimalist but working support for @GradleBuild that triggers a Gradle-build
and retrieves the built WAR-file as a Shrinkwrap-archive as deployment.
Currently, it will grab the first WAR-file it finds under build/libs.
This will not work for EAR multi-project but should be sufficient for 95% of use-cases.

As there is no EmbeddedGradle-equivalent to EmbeddedMaven in shrinkwrap/resolver that can run builds; there only is GradleResolverSystem.
I have directly used the Gradle Tooling API in here. In the bigger picture, I assume it would make sense to rely on extended Gradle-support in shrinkwrap/resolver as the @MavenBuild does.

#### Changes proposed in this pull request:

No changes; just additional features.


**Fixes**: #80 
