### PR TITLE
Adds support for Wildfly 12 and Wildfly 13 see #91

### DIFF
--- a/arquillian-chameleon-container-model/src/main/resources/chameleon/default/containers.yaml
+++ b/arquillian-chameleon-container-model/src/main/resources/chameleon/default/containers.yaml
@@ -332,17 +332,17 @@
     - org.jboss.shrinkwrap.resolver:*
     - "*:wildfly-arquillian-testenricher-msc"
 - name: WildFly
-  versionExpression: [10.*|11.*]
+  versionExpression: [10.*|11.*|12.*|13.*]
   adapters:
     - type: remote
-      coordinates: org.wildfly.arquillian:wildfly-arquillian-container-remote:2.1.0.Final
+      coordinates: org.wildfly.arquillian:wildfly-arquillian-container-remote:2.1.1.Final
       adapterClass: org.jboss.as.arquillian.container.remote.RemoteDeployableContainer
     - type: managed
-      coordinates: org.wildfly.arquillian:wildfly-arquillian-container-managed:2.1.0.Final
+      coordinates: org.wildfly.arquillian:wildfly-arquillian-container-managed:2.1.1.Final
       adapterClass: org.jboss.as.arquillian.container.managed.ManagedDeployableContainer
       configuration: *WF_CONFIG
     - type: embedded
-      coordinates: org.wildfly.arquillian:wildfly-arquillian-container-embedded:2.1.0.Final
+      coordinates: org.wildfly.arquillian:wildfly-arquillian-container-embedded:2.1.1.Final
       adapterClass: org.jboss.as.arquillian.container.embedded.EmbeddedDeployableContainer
       configuration: *WF_EMBEDD_CONFIG
   defaultType: managed
@@ -360,14 +360,14 @@
     - org.jboss.shrinkwrap.resolver:*
     - "*:wildfly-arquillian-testenricher-msc"
 - name: WildFly Domain
-  versionExpression: [10.*|11.*]
+  versionExpression: [10.*|11.*|12.*|13.*]
   adapters:
     - type: managed
-      coordinates: org.wildfly.arquillian:wildfly-arquillian-container-domain-managed:2.1.0.Final
+      coordinates: org.wildfly.arquillian:wildfly-arquillian-container-domain-managed:2.1.1.Final
       adapterClass: org.jboss.as.arquillian.container.domain.managed.ManagedDomainDeployableContainer
       configuration: *WF_CONFIG
     - type: remote
-      coordinates: org.wildfly.arquillian:wildfly-arquillian-container-domain-remote:2.1.0.Final
+      coordinates: org.wildfly.arquillian:wildfly-arquillian-container-domain-remote:2.1.1.Final
       adapterClass: org.jboss.as.arquillian.container.domain.remote.RemoteDomainDeployableContainer
   defaultType: managed
   dist: *WF_DIST

--- a/arquillian-chameleon-extension/src/test/java/org/arquillian/container/chameleon/ContainerTestCase.java
+++ b/arquillian-chameleon-extension/src/test/java/org/arquillian/container/chameleon/ContainerTestCase.java
@@ -195,7 +195,7 @@ public class ContainerTestCase {
     public void resolveWildFly10() throws Exception {
         ContainerAdapter adapter = load("wildfly:10.0.0.Beta2:managed");
         Assert.assertEquals(
-            "org.wildfly.arquillian:wildfly-arquillian-container-managed:2.1.0.Final",
+            "org.wildfly.arquillian:wildfly-arquillian-container-managed:2.1.1.Final",
             adapter.dependencies()[0]);
     }
 
@@ -203,7 +203,7 @@ public class ContainerTestCase {
     public void resolveWildFly10DomainManaged() throws Exception {
         ContainerAdapter adapter = load("wildfly domain:10.0.0.Final:managed");
         Assert.assertEquals(
-            "org.wildfly.arquillian:wildfly-arquillian-container-domain-managed:2.1.0.Final",
+            "org.wildfly.arquillian:wildfly-arquillian-container-domain-managed:2.1.1.Final",
             adapter.dependencies()[0]);
     }
 
@@ -211,7 +211,7 @@ public class ContainerTestCase {
     public void resolveWildFly10DomainRemote() throws Exception {
         ContainerAdapter adapter = load("wildfly domain:10.0.0.Final:remote");
         Assert.assertEquals(
-            "org.wildfly.arquillian:wildfly-arquillian-container-domain-remote:2.1.0.Final",
+            "org.wildfly.arquillian:wildfly-arquillian-container-domain-remote:2.1.1.Final",
             adapter.dependencies()[0]);
     }
 
@@ -219,7 +219,7 @@ public class ContainerTestCase {
     public void resolveWildFly11() throws Exception {
         ContainerAdapter adapter = load("wildfly:11.0.0.Final:managed");
         Assert.assertEquals(
-            "org.wildfly.arquillian:wildfly-arquillian-container-managed:2.1.0.Final",
+            "org.wildfly.arquillian:wildfly-arquillian-container-managed:2.1.1.Final",
             adapter.dependencies()[0]);
     }
 
@@ -227,7 +227,7 @@ public class ContainerTestCase {
     public void resolveWildFly11DomainManaged() throws Exception {
         ContainerAdapter adapter = load("wildfly domain:11.0.0.Final:managed");
         Assert.assertEquals(
-            "org.wildfly.arquillian:wildfly-arquillian-container-domain-managed:2.1.0.Final",
+            "org.wildfly.arquillian:wildfly-arquillian-container-domain-managed:2.1.1.Final",
             adapter.dependencies()[0]);
     }
 
@@ -235,7 +235,7 @@ public class ContainerTestCase {
     public void resolveWildFly11DomainRemote() throws Exception {
         ContainerAdapter adapter = load("wildfly domain:11.0.0.Final:remote");
         Assert.assertEquals(
-            "org.wildfly.arquillian:wildfly-arquillian-container-domain-remote:2.1.0.Final",
+            "org.wildfly.arquillian:wildfly-arquillian-container-domain-remote:2.1.1.Final",
             adapter.dependencies()[0]);
     }
 
@@ -264,6 +264,54 @@ public class ContainerTestCase {
         Assert.assertEquals(
             "c:\\test",
             resolvedConfig.get("jbossHome"));
+    }
+
+    @Test
+    public void resolveWildFly12() throws Exception {
+        ContainerAdapter adapter = load("wildfly:12.0.0.Final:managed");
+        Assert.assertEquals(
+            "org.wildfly.arquillian:wildfly-arquillian-container-managed:2.1.1.Final",
+            adapter.dependencies()[0]);
+    }
+
+    @Test
+    public void resolveWildFly12DomainManaged() throws Exception {
+        ContainerAdapter adapter = load("wildfly domain:12.0.0.Final:managed");
+        Assert.assertEquals(
+            "org.wildfly.arquillian:wildfly-arquillian-container-domain-managed:2.1.1.Final",
+            adapter.dependencies()[0]);
+    }
+
+    @Test
+    public void resolveWildFly12DomainRemote() throws Exception {
+        ContainerAdapter adapter = load("wildfly domain:12.0.0.Final:remote");
+        Assert.assertEquals(
+            "org.wildfly.arquillian:wildfly-arquillian-container-domain-remote:2.1.1.Final",
+            adapter.dependencies()[0]);
+    }
+
+    @Test
+    public void resolveWildFly13() throws Exception {
+        ContainerAdapter adapter = load("wildfly:13.0.0.Final:managed");
+        Assert.assertEquals(
+            "org.wildfly.arquillian:wildfly-arquillian-container-managed:2.1.1.Final",
+            adapter.dependencies()[0]);
+    }
+
+    @Test
+    public void resolveWildFly13DomainManaged() throws Exception {
+        ContainerAdapter adapter = load("wildfly domain:13.0.0.Final:managed");
+        Assert.assertEquals(
+            "org.wildfly.arquillian:wildfly-arquillian-container-domain-managed:2.1.1.Final",
+            adapter.dependencies()[0]);
+    }
+
+    @Test
+    public void resolveWildFly13DomainRemote() throws Exception {
+        ContainerAdapter adapter = load("wildfly domain:13.0.0.Final:remote");
+        Assert.assertEquals(
+            "org.wildfly.arquillian:wildfly-arquillian-container-domain-remote:2.1.1.Final",
+            adapter.dependencies()[0]);
     }
 
     private ContainerAdapter load(String target) throws Exception {


### PR DESCRIPTION
#### Short description of what this resolves:

Adds support for Wildfly 12 and Wildfly 13 see #91

#### Changes proposed in this pull request:

- Added configuration to support Wildfly 12/13 (same as 11, not big changes that may affect arquillian)
- Upgrades adapter version to 2.1.1.Final released some days ago
- Added tests 


**Fixes**: #91 
