### PR TITLE
Adds support for properties in @ChameleonTarget value attribute

### DIFF
--- a/arquillian-chameleon-runner/ftest/pom.xml
+++ b/arquillian-chameleon-runner/ftest/pom.xml
@@ -48,5 +48,27 @@
 
   </dependencies>
 
+  <build>
+  <!-- used by GreetingServiceSystemPropertiesTest -->
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.0</version>
+        <configuration>
+          <systemPropertyVariables>
+            <arquillian.container>wildfly:8.2.0.Final:managed</arquillian.container>
+          </systemPropertyVariables>
+           <systemProperties>
+            <property>
+              <name>arquillian.container</name>
+              <value>wildfly:8.2.0.Final:managed</value>
+            </property>
+          </systemProperties>
+        </configuration>
+      </plugin>
+     </plugins>
+  </build>
+
 </project>
 

--- a/arquillian-chameleon-runner/ftest/pom.xml
+++ b/arquillian-chameleon-runner/ftest/pom.xml
@@ -59,12 +59,6 @@
           <systemPropertyVariables>
             <arquillian.container>wildfly:8.2.0.Final:managed</arquillian.container>
           </systemPropertyVariables>
-           <systemProperties>
-            <property>
-              <name>arquillian.container</name>
-              <value>wildfly:8.2.0.Final:managed</value>
-            </property>
-          </systemProperties>
         </configuration>
       </plugin>
      </plugins>

--- a/arquillian-chameleon-runner/ftest/src/test/java/org/arquillian/container/chameleon/GreetingServiceSystemPropertiesTest.java
+++ b/arquillian-chameleon-runner/ftest/src/test/java/org/arquillian/container/chameleon/GreetingServiceSystemPropertiesTest.java
@@ -1,6 +1,12 @@
 package org.arquillian.container.chameleon;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
 import javax.inject.Inject;
+
+import org.arquillian.container.chameleon.api.ChameleonTarget;
 import org.arquillian.container.chameleon.runner.ArquillianChameleon;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -8,13 +14,9 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
-
-@Wildfly
+@ChameleonTarget("${arquillian.container}")
 @RunWith(ArquillianChameleon.class)
-public class GreetingServiceTest {
+public class GreetingServiceSystemPropertiesTest {
 
     @Deployment
     public static WebArchive deployService() {

--- a/arquillian-chameleon-runner/runner/src/main/java/org/arquillian/container/chameleon/runner/ChameleonTargetConfiguration.java
+++ b/arquillian-chameleon-runner/runner/src/main/java/org/arquillian/container/chameleon/runner/ChameleonTargetConfiguration.java
@@ -7,7 +7,6 @@ import java.util.Set;
 import org.arquillian.container.chameleon.api.ChameleonTarget;
 import org.arquillian.container.chameleon.api.Mode;
 import org.arquillian.container.chameleon.api.Property;
-import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -61,7 +60,7 @@ public class ChameleonTargetConfiguration {
                 toMap(chameleonTarget.customProperties()));
         } else {
             final ChameleonTargetConfiguration chameleonTargetConfiguration =
-                new ChameleonTargetConfiguration(chameleonTarget.value());
+                new ChameleonTargetConfiguration(parseExpressions(chameleonTarget.value()));
             chameleonTargetConfiguration.customProperties = toMap(chameleonTarget.customProperties());
 
             return chameleonTargetConfiguration;

--- a/arquillian-chameleon-runner/runner/src/test/java/org/arquillian/container/chameleon/runner/AnnotationExtractorTest.java
+++ b/arquillian-chameleon-runner/runner/src/test/java/org/arquillian/container/chameleon/runner/AnnotationExtractorTest.java
@@ -1,10 +1,9 @@
 package org.arquillian.container.chameleon.runner;
 
-import java.lang.annotation.Annotation;
-import java.util.Map;
 import org.arquillian.container.chameleon.api.ChameleonTarget;
 import org.arquillian.container.chameleon.api.Mode;
 import org.arquillian.container.chameleon.runner.fixtures.GenericTest;
+import org.arquillian.container.chameleon.runner.fixtures.SystemPropertiesTest;
 import org.arquillian.container.chameleon.runner.fixtures.Tomcat;
 import org.arquillian.container.chameleon.runner.fixtures.Tomcat8;
 import org.arquillian.container.chameleon.runner.fixtures.Tomcat8Test;
@@ -17,7 +16,7 @@ import static org.assertj.core.api.Assertions.entry;
 public class AnnotationExtractorTest {
 
     @Test
-    public void should_get_roeprties_from_chameleon_annotation() {
+    public void should_get_proeprties_from_chameleon_annotation() {
 
         // given
         final ChameleonTarget chameleonTarget = GenericTest.class.getAnnotation(ChameleonTarget.class);
@@ -30,6 +29,22 @@ public class AnnotationExtractorTest {
         assertThat(chameleonTargetConfiguration.getVersion()).isEqualTo("7.0.0");
         assertThat(chameleonTargetConfiguration.getMode()).isEqualTo(Mode.MANAGED);
         assertThat(chameleonTargetConfiguration.getCustomProperties()).contains(entry("a", "b"));
+    }
+    
+    @Test
+    public void should_get_proeprties_from_chameleon_annotation_with_system_properties() {
+
+        // given
+    	System.setProperty("arquillian.container", "wildfly:8.2.0.Final:managed");
+        final ChameleonTarget chameleonTarget = SystemPropertiesTest.class.getAnnotation(ChameleonTarget.class);
+
+        // when
+        final ChameleonTargetConfiguration chameleonTargetConfiguration = AnnotationExtractor.extract(chameleonTarget);
+
+        // then
+        assertThat(chameleonTargetConfiguration.getContainer()).isEqualTo("wildfly");
+        assertThat(chameleonTargetConfiguration.getVersion()).isEqualTo("8.2.0.Final");
+        assertThat(chameleonTargetConfiguration.getMode()).isEqualTo(Mode.MANAGED);
     }
 
     @Test
@@ -45,8 +60,8 @@ public class AnnotationExtractorTest {
         assertThat(chameleonTargetConfiguration.getContainer()).isEqualTo("tomcat");
         assertThat(chameleonTargetConfiguration.getVersion()).isEqualTo("7.0.0");
         assertThat(chameleonTargetConfiguration.getMode()).isEqualTo(Mode.MANAGED);
-
     }
+    
 
     @Test
     public void should_navigate_through_all_hierarchy_of_configurations() {

--- a/arquillian-chameleon-runner/runner/src/test/java/org/arquillian/container/chameleon/runner/fixtures/SystemPropertiesTest.java
+++ b/arquillian-chameleon-runner/runner/src/test/java/org/arquillian/container/chameleon/runner/fixtures/SystemPropertiesTest.java
@@ -1,0 +1,7 @@
+package org.arquillian.container.chameleon.runner.fixtures;
+
+import org.arquillian.container.chameleon.api.ChameleonTarget;
+
+@ChameleonTarget("${arquillian.container}")
+public class SystemPropertiesTest {
+}


### PR DESCRIPTION
 

#### Short description of what this resolves:

Adds support for system/env properties in @ChameleonTarget, e.g:

```
@ChameleonTarget("${arquillian.container}")
```

#### Changes proposed in this pull request:

- Use System properties resolver in chameleon target **value** (same as done in other ChameleonTarget properties like `container`, `version` and `mode`)
- Adds unit and ftess for system properties


**Fixes**: #107 
