### PR TITLE
Added Wildfly 12, 13 to the supported containers

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -72,6 +72,8 @@ Example chameleonTarget values:
 ** 6.x
 ** 7.x
 * WildFly
+** 13.x
+** 12.x
 ** 11.x
 ** 10.x
 ** 9.x


### PR DESCRIPTION
#### Short description of what this resolves:
Missing specific wildfly versions in the list of supported containers

#### Changes proposed in this pull request:
Added version 12 and 13 to the list

This was done on https://github.com/arquillian/arquillian-container-chameleon/issues/91
