### PR TITLE
Adds Tomee 7/8 support

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -87,10 +87,14 @@ Example chameleonTarget values:
 ** 5.x
 * Payara
 ** 4.x
+** 5.x
 * Tomcat
 ** 8.0.*
 ** 7.x
 ** 6.x
+* Tomee
+** 7.x (embedded mode not supported)
+** 8.x (embedded mode not supported)
 
 [NOTE]
 Chameleon will download and extract the target container if no distribution home is configured and target type is either embedded or managed.

--- a/arquillian-chameleon-container-model/src/main/resources/chameleon/default/containers.yaml
+++ b/arquillian-chameleon-container-model/src/main/resources/chameleon/default/containers.yaml
@@ -490,32 +490,32 @@
   versionExpression: 1.*
   adapters:
     - type: remote
-      coordinates: org.apache.openejb:arquillian-tomee-remote:1.7.5
+      coordinates: org.apache.openejb:arquillian-tomee-remote:${version}
       adapterClass: org.apache.tomee.arquillian.remote.RemoteTomEEContainer
     - type: managed
-      coordinates: org.apache.openejb:arquillian-tomee-remote:1.7.5
+      coordinates: org.apache.openejb:arquillian-tomee-remote:${version}
       adapterClass: org.apache.tomee.arquillian.remote.RemoteTomEEContainer
       requireDist: false
     - type: embedded
-      coordinates: org.apache.openejb:arquillian-tomee-embedded:1.7.5
+      coordinates: org.apache.openejb:arquillian-tomee-embedded:${version}
       adapterClass: org.apache.openejb.arquillian.embedded.EmbeddedTomEEContainer
       requireDist: false
   dist:  
     coordinates: org.apache.openejb:apache-tomee:zip:${version}     
       
 - name: TomEE
-  versionExpression: 7.*
+  versionExpression: [7.*|8.*]
   adapters:
     - type: remote
-      coordinates: org.apache.tomee:arquillian-tomee-remote:7.0.5
+      coordinates: org.apache.tomee:arquillian-tomee-remote:${version}
       adapterClass: org.apache.tomee.arquillian.remote.RemoteTomEEContainer
     - type: managed
-      coordinates: org.apache.tomee:arquillian-tomee-remote:7.0.5
+      coordinates: org.apache.tomee:arquillian-tomee-remote:${version}
       adapterClass: org.apache.tomee.arquillian.remote.RemoteTomEEContainer
       requireDist: false
     - type: embedded
-      coordinates: org.apache.tomee:arquillian-tomee-embedded:7.0.5
+      coordinates: org.apache.tomee:arquillian-tomee-embedded:${version}
       adapterClass: org.apache.openejb.arquillian.embedded.EmbeddedTomEEContainer
       requireDist: false   
   dist:  
-    coordinates: org.apache.tomee:apache-tomee:zip:${version}    
+    coordinates: org.apache.tomee:apache-tomee:zip:${version}

--- a/arquillian-chameleon-container-model/src/main/resources/chameleon/default/containers.yaml
+++ b/arquillian-chameleon-container-model/src/main/resources/chameleon/default/containers.yaml
@@ -485,3 +485,37 @@
       configuration: *TOMCAT_MANAGED_CONFIG
   defaultType: managed
   dist: *TOMCAT_DIST
+  
+- name: TomEE
+  versionExpression: 1.*
+  adapters:
+    - type: remote
+      coordinates: org.apache.openejb:arquillian-tomee-remote:1.7.5
+      adapterClass: org.apache.tomee.arquillian.remote.RemoteTomEEContainer
+    - type: managed
+      coordinates: org.apache.openejb:arquillian-tomee-remote:1.7.5
+      adapterClass: org.apache.tomee.arquillian.remote.RemoteTomEEContainer
+      requireDist: false
+    - type: embedded
+      coordinates: org.apache.openejb:arquillian-tomee-embedded:1.7.5
+      adapterClass: org.apache.openejb.arquillian.embedded.EmbeddedTomEEContainer
+      requireDist: false
+  dist:  
+    coordinates: org.apache.openejb:apache-tomee:zip:${version}     
+      
+- name: TomEE
+  versionExpression: 7.*
+  adapters:
+    - type: remote
+      coordinates: org.apache.tomee:arquillian-tomee-remote:7.0.5
+      adapterClass: org.apache.tomee.arquillian.remote.RemoteTomEEContainer
+    - type: managed
+      coordinates: org.apache.tomee:arquillian-tomee-remote:7.0.5
+      adapterClass: org.apache.tomee.arquillian.remote.RemoteTomEEContainer
+      requireDist: false
+    - type: embedded
+      coordinates: org.apache.tomee:arquillian-tomee-embedded:7.0.5
+      adapterClass: org.apache.openejb.arquillian.embedded.EmbeddedTomEEContainer
+      requireDist: false   
+  dist:  
+    coordinates: org.apache.tomee:apache-tomee:zip:${version}    

--- a/arquillian-chameleon-extension/pom.xml
+++ b/arquillian-chameleon-extension/pom.xml
@@ -345,6 +345,49 @@
                   </systemPropertyVariables>
                 </configuration>
               </execution>
+              <!-- Tomee -->
+              <execution>
+                <id>tomee7-managed</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <skip>false</skip>
+                  <test>SimpleDeploymentTestCase</test>
+                  <systemPropertyVariables>
+                    <arq.container.chameleon.configuration.chameleonTarget>tomee:7.0.5:managed
+                    </arq.container.chameleon.configuration.chameleonTarget>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+              <execution>
+                <id>tomee7-remote</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <skip>false</skip>
+                  <test>SimpleDeploymentTestCase</test>
+                  <systemPropertyVariables>
+                    <arq.container.chameleon.configuration.chameleonTarget>tomee:7.0.5:remote
+                    </arq.container.chameleon.configuration.chameleonTarget>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+              <execution>
+                <id>tomee8-managed</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <skip>false</skip>
+                  <test>SimpleDeploymentTestCase</test>
+                  <systemPropertyVariables>
+                    <arq.container.chameleon.configuration.chameleonTarget>tomee:8.0.0-M1:managed
+                    </arq.container.chameleon.configuration.chameleonTarget>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
               <execution>
                 <id>wf10-domain</id>
                 <goals>

--- a/arquillian-chameleon-runner/ftest/pom.xml
+++ b/arquillian-chameleon-runner/ftest/pom.xml
@@ -1,68 +1,91 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <parent>
-    <artifactId>arquillian-container-chameleon-runner-parent</artifactId>
-    <groupId>org.arquillian.container</groupId>
-    <version>1.0.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
-  </parent>
-  <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>arquillian-container-chameleon-runner-parent</artifactId>
+        <groupId>org.arquillian.container</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>arquillian-container-chameleon-runner-ftest</artifactId>
+    <artifactId>arquillian-container-chameleon-runner-ftest</artifactId>
 
-  <name>Arquillian Container Chameleon Runner Functional Test</name>
+    <name>Arquillian Container Chameleon Runner Functional Test</name>
 
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>org.arquillian.container</groupId>
-      <artifactId>arquillian-container-chameleon</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>org.arquillian.container</groupId>
+            <artifactId>arquillian-container-chameleon</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>org.arquillian.container</groupId>
-      <artifactId>arquillian-container-chameleon-runner</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>org.arquillian.container</groupId>
+            <artifactId>arquillian-container-chameleon-runner</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-container</artifactId>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>javax</groupId>
-      <artifactId>javaee-api</artifactId>
-      <version>7.0</version>
-      <scope>provided</scope>
-    </dependency>
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>7.0</version>
+            <scope>provided</scope>
+        </dependency>
 
-  </dependencies>
+    </dependencies>
 
-  <build>
-  <!-- used by GreetingServiceSystemPropertiesTest -->
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.0</version>
-        <configuration>
-          <systemPropertyVariables>
-            <arquillian.container>wildfly:8.2.0.Final:managed</arquillian.container>
-          </systemPropertyVariables>
-        </configuration>
-      </plugin>
-     </plugins>
-  </build>
+    <build>
+        <!-- used by GreetingServiceSystemPropertiesTest -->
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.0</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <arquillian.container>wildfly:8.2.0.Final:managed</arquillian.container>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+  
+    <profiles>
+        <profile>
+            <id>tomee7</id>
+          
+            <build>
+                <!-- used by GreetingServiceSystemPropertiesTest -->
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.22.0</version>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <arquillian.container>tomee:7.0.5-plus:managed</arquillian.container>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+      
+    </profiles>    
 
 </project>
 

--- a/arquillian-chameleon-runner/ftest/pom.xml
+++ b/arquillian-chameleon-runner/ftest/pom.xml
@@ -64,27 +64,5 @@
      </plugins>
   </build>
 
-    <profiles>
-        <profile>
-            <id>tomee7</id>
-            <build>
-                <!-- used by GreetingServiceSystemPropertiesTest -->
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.22.0</version>
-                        <configuration>
-                            <systemPropertyVariables>
-                                <arquillian.container>tomee:7.0.5-plus:managed</arquillian.container>
-                            </systemPropertyVariables>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-    </profiles>
-
 </project>
 

--- a/arquillian-chameleon-runner/ftest/pom.xml
+++ b/arquillian-chameleon-runner/ftest/pom.xml
@@ -67,7 +67,6 @@
     <profiles>
         <profile>
             <id>tomee7</id>
-
             <build>
                 <!-- used by GreetingServiceSystemPropertiesTest -->
                 <plugins>

--- a/arquillian-chameleon-runner/ftest/src/test/java/org/arquillian/container/chameleon/GreetingServiceTomeeTest.java
+++ b/arquillian-chameleon-runner/ftest/src/test/java/org/arquillian/container/chameleon/GreetingServiceTomeeTest.java
@@ -1,0 +1,34 @@
+package org.arquillian.container.chameleon;
+
+import org.arquillian.container.chameleon.runner.ArquillianChameleon;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+@Tomee
+@RunWith(ArquillianChameleon.class)
+public class GreetingServiceTomeeTest {
+
+    @Deployment
+    public static WebArchive deployService() {
+        return ShrinkWrap.create(WebArchive.class)
+            .addClass(GreetingService.class);
+    }
+
+    @Inject
+    private GreetingService service;
+
+    @Test
+    public void should_get_greetings() {
+        assertThat(service, is(notNullValue()));
+    }
+
+}

--- a/arquillian-chameleon-runner/ftest/src/test/java/org/arquillian/container/chameleon/Tomee.java
+++ b/arquillian-chameleon-runner/ftest/src/test/java/org/arquillian/container/chameleon/Tomee.java
@@ -1,0 +1,13 @@
+package org.arquillian.container.chameleon;
+
+import org.arquillian.container.chameleon.api.ChameleonTarget;
+
+import java.lang.annotation.*;
+
+@Target({ ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ChameleonTarget("tomee:7.0.5:managed")
+public @interface Tomee {
+}


### PR DESCRIPTION
#### Short description of what this resolves:

Adds Tomee containers to default chameleon configuration.


**Important**: Tomee 1.7.x (managed/remote/embedded) and embedded containers **are not working**!

In other words this PR brings support to Tomee 7 and Tomee 8 on managed and remote modes.
 

#### Changes proposed in this pull request:

- Adds tomee container adapter classes to default containers configuration
- Adds tomee tests 


**Fixes**: #31 
