### PR TITLE
adds the possibility to use maven from a local installation

### DIFF
--- a/arquillian-chameleon-deployments/arquillian-chameleon-maven-build-deployment/pom.xml
+++ b/arquillian-chameleon-deployments/arquillian-chameleon-maven-build-deployment/pom.xml
@@ -45,6 +45,13 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>1.19.0</version>
+      <scope>test</scope>
+    </dependency>
+
 
   </dependencies>
 

--- a/arquillian-chameleon-deployments/arquillian-chameleon-maven-build-deployment/src/main/java/org/arquillian/container/chameleon/deployment/maven/MavenBuild.java
+++ b/arquillian-chameleon-deployments/arquillian-chameleon-maven-build-deployment/src/main/java/org/arquillian/container/chameleon/deployment/maven/MavenBuild.java
@@ -70,4 +70,10 @@ public @interface MavenBuild {
      */
     boolean quiet() default true;
 
+    /**
+     * Uses maven from the local PATH. Any version defined in the "version" property will be ignored.
+     * @return
+     */
+    boolean useLocalInstallation() default false;
+
 }

--- a/arquillian-chameleon-deployments/arquillian-chameleon-maven-build-deployment/src/main/java/org/arquillian/container/chameleon/deployment/maven/MavenBuildAutomaticDeployment.java
+++ b/arquillian-chameleon-deployments/arquillian-chameleon-maven-build-deployment/src/main/java/org/arquillian/container/chameleon/deployment/maven/MavenBuildAutomaticDeployment.java
@@ -24,12 +24,7 @@ public class MavenBuildAutomaticDeployment extends AbstractAutomaticDeployment {
     }
 
     private Archive<?> runBuild(MavenBuild conf) {
-        final ConfigurationDistributionStage configurationDistributionStage = EmbeddedMaven.forProject(conf.pom())
-            .useMaven3Version(conf.version())
-            .setGoals(conf.goals())
-            .setProfiles(conf.profiles())
-            .setOffline(conf.offline())
-            .skipTests(true);
+        final ConfigurationDistributionStage configurationDistributionStage = getConfigurationDistributionStage(conf);
 
         configurationDistributionStage.setQuiet(conf.quiet());
 
@@ -69,6 +64,20 @@ public class MavenBuildAutomaticDeployment extends AbstractAutomaticDeployment {
 
         return build.getDefaultBuiltArchive();
 
+    }
+
+    ConfigurationDistributionStage getConfigurationDistributionStage(MavenBuild conf) {
+        ConfigurationDistributionStage configurationDistributionStage = EmbeddedMaven.forProject(conf.pom());
+        if (conf.useLocalInstallation()) {
+            configurationDistributionStage.useLocalInstallation();
+        } else {
+            configurationDistributionStage.useMaven3Version(conf.version());
+        }
+
+        return configurationDistributionStage.setGoals(conf.goals())
+            .setProfiles(conf.profiles())
+            .setOffline(conf.offline())
+            .skipTests(true);
     }
 
     private boolean isModuleSet(MavenBuild conf) {

--- a/arquillian-chameleon-deployments/arquillian-chameleon-maven-build-deployment/src/test/java/org/arquillian/container/chameleon/deployment/maven/MavenBuildAutomaticDeploymentTest.java
+++ b/arquillian-chameleon-deployments/arquillian-chameleon-maven-build-deployment/src/test/java/org/arquillian/container/chameleon/deployment/maven/MavenBuildAutomaticDeploymentTest.java
@@ -15,33 +15,42 @@ public class MavenBuildAutomaticDeploymentTest {
 
     @Test
     public void should_get_archive_from_module() {
+        // given
+        // when
         final Archive<?> archive = buildWithTestCaseClass(TestCaseClass.class);
 
+        //then
         assertThat(archive.toString())
             .startsWith("arquillian-chameleon-deployment-api");
     }
 
     @Test
-    public void givenTheMavenBuildWithLocalInstallation_whenMavenIsInThePath_thenItMustBuild() {
+    public void should_get_archive_from_module_built_by_local_maven_installation() {
 
+        // given maven in the path
         if (System.getenv("maven.home") == null && System.getenv("M2_HOME") == null) {
             environmentVariables.set("M2_HOME", "/usr/local/maven"); // default location in travis-ci machine.
         }
 
+        // when @MavenBuild useLocalInstallation = true
         final Archive<?> archive = buildWithTestCaseClass(TestCaseLocalMavenClass.class);
 
+        // then
         assertThat(archive.toString())
             .startsWith("arquillian-chameleon-deployment-api");
     }
 
     @Test(expected = IllegalStateException.class) //thrown by shrinkwrap maven resolver
-    public void givenTheMavenBuildWithLocalInstallation_whenMavenIsNotInThePath_thenItThrowsAnException() {
+    public void should_throw_exception_due_to_no_maven_found() {
 
+        // given no maven in the path
         environmentVariables.set("M2_HOME", "/path/to/nowhere");
         environmentVariables.set("maven.home", "/path/to/nowhere");
 
+        // when
         MavenBuildAutomaticDeployment mavenBuildAutomaticDeployment = new MavenBuildAutomaticDeployment();
 
+        //then throws
         mavenBuildAutomaticDeployment.build(new TestClass(TestCaseLocalMavenClass.class));
 
     }

--- a/arquillian-chameleon-deployments/arquillian-chameleon-maven-build-deployment/src/test/java/org/arquillian/container/chameleon/deployment/maven/MavenBuildAutomaticDeploymentTest.java
+++ b/arquillian-chameleon-deployments/arquillian-chameleon-maven-build-deployment/src/test/java/org/arquillian/container/chameleon/deployment/maven/MavenBuildAutomaticDeploymentTest.java
@@ -23,6 +23,11 @@ public class MavenBuildAutomaticDeploymentTest {
 
     @Test
     public void givenTheMavenBuildWithLocalInstallation_whenMavenIsInThePath_thenItMustBuild() {
+
+        if (System.getenv("maven.home") == null && System.getenv("M2_HOME") == null) {
+            environmentVariables.set("M2_HOME", "/usr/local/maven"); // default location in travis-ci machine.
+        }
+
         final Archive<?> archive = buildWithTestCaseClass(TestCaseLocalMavenClass.class);
 
         assertThat(archive.toString())
@@ -33,6 +38,7 @@ public class MavenBuildAutomaticDeploymentTest {
     public void givenTheMavenBuildWithLocalInstallation_whenMavenIsNotInThePath_thenItThrowsAnException() {
 
         environmentVariables.set("M2_HOME", "/path/to/nowhere");
+        environmentVariables.set("maven.home", "/path/to/nowhere");
 
         MavenBuildAutomaticDeployment mavenBuildAutomaticDeployment = new MavenBuildAutomaticDeployment();
 

--- a/arquillian-chameleon-deployments/arquillian-chameleon-maven-build-deployment/src/test/java/org/arquillian/container/chameleon/deployment/maven/MavenBuildAutomaticDeploymentTest.java
+++ b/arquillian-chameleon-deployments/arquillian-chameleon-maven-build-deployment/src/test/java/org/arquillian/container/chameleon/deployment/maven/MavenBuildAutomaticDeploymentTest.java
@@ -2,30 +2,60 @@ package org.arquillian.container.chameleon.deployment.maven;
 
 import org.jboss.arquillian.test.spi.TestClass;
 import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MavenBuildAutomaticDeploymentTest {
 
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
     @Test
     public void should_get_archive_from_module() {
+        final Archive<?> archive = buildWithTestCaseClass(TestCaseClass.class);
 
-        // given
-        MavenBuildAutomaticDeployment mavenBuildAutomaticDeployment = new MavenBuildAutomaticDeployment();
-
-        // when
-        final Archive<?> archive = mavenBuildAutomaticDeployment.build(new TestClass(TestCaseClass.class));
-
-        // then
         assertThat(archive.toString())
             .startsWith("arquillian-chameleon-deployment-api");
+    }
+
+    @Test
+    public void givenTheMavenBuildWithLocalInstallation_whenMavenIsInThePath_thenItMustBuild() {
+        final Archive<?> archive = buildWithTestCaseClass(TestCaseLocalMavenClass.class);
+
+        assertThat(archive.toString())
+            .startsWith("arquillian-chameleon-deployment-api");
+    }
+
+    @Test(expected = IllegalStateException.class) //thrown by shrinkwrap maven resolver
+    public void givenTheMavenBuildWithLocalInstallation_whenMavenIsNotInThePath_thenItThrowsAnException() {
+
+        environmentVariables.set("M2_HOME", "/path/to/nowhere");
+
+        MavenBuildAutomaticDeployment mavenBuildAutomaticDeployment = new MavenBuildAutomaticDeployment();
+
+        mavenBuildAutomaticDeployment.build(new TestClass(TestCaseLocalMavenClass.class));
+
+    }
+
+    private Archive<?> buildWithTestCaseClass(Class<?> testClass) {
+        MavenBuildAutomaticDeployment mavenBuildAutomaticDeployment = new MavenBuildAutomaticDeployment();
+        return mavenBuildAutomaticDeployment.build(new TestClass(testClass));
     }
 
     @MavenBuild(pom = "../../pom.xml",
         module = "arquillian-chameleon-deployments/arquillian-chameleon-deployment-api"
     )
     static class TestCaseClass {
+    }
+
+    @MavenBuild(pom = "../../pom.xml",
+        module = "arquillian-chameleon-deployments/arquillian-chameleon-deployment-api",
+        useLocalInstallation = true
+    )
+    static class TestCaseLocalMavenClass {
     }
 
 }


### PR DESCRIPTION
this will basically tell shrinkwrap resolver not to use a specific
maven installation, preventing it to download it from the internet
and, instead, using it from the local (either from maven.home or
M2_HOME env variables).

This behavior is specified [here](https://maven.apache.org/shared/maven-invoker/apidocs/org/apache/maven/shared/invoker/Invoker.html#setMavenHome-java.io.File-).

This feature is useful when running arquillian tests from within
an environment with no internet access.

I'm not convinced however, about how to properly test this change. I've added two tests there, but it is a bit of a indirection to me, so if you guys see something better, please...

It solves https://github.com/arquillian/arquillian-container-chameleon/issues/148